### PR TITLE
Primitive logging of PyTest exception messages

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -2,7 +2,7 @@
 # and/or modify it under the terms of the GPL licence
 
 import logging
-import html
+import cgi
 
 import pytest
 
@@ -23,7 +23,7 @@ class RP_Report_Listener(object):
         report = (yield).get_result()
 
         if report.longrepr:
-            PyTestService.post_log(html.escape(str(report.longrepr)), logging.ERROR)
+            PyTestService.post_log(cgi.escape(str(report.longrepr)), logging.ERROR)
 
         if report.when == "setup":
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -1,7 +1,11 @@
-import pytest
 # This program is free software: you can redistribute it
 # and/or modify it under the terms of the GPL licence
+
 import logging
+import html
+
+import pytest
+
 from .service import PyTestService
 
 
@@ -17,6 +21,10 @@ class RP_Report_Listener(object):
     @pytest.mark.hookwrapper
     def pytest_runtest_makereport(self, item, call):
         report = (yield).get_result()
+
+        if report.longrepr:
+            PyTestService.post_log(html.escape(str(report.longrepr)), logging.ERROR)
+
         if report.when == "setup":
 
             # when function pytest_setup is called,

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -23,7 +23,7 @@ class RP_Report_Listener(object):
         report = (yield).get_result()
 
         if report.longrepr:
-            PyTestService.post_log(cgi.escape(str(report.longrepr)), logging.ERROR)
+            PyTestService.post_log(cgi.escape(report.longreprtext), logging.ERROR)
 
         if report.when == "setup":
 


### PR DESCRIPTION
This changeset provide logging of PyTest exceptions (see issue #4). It looks like this:
![primitive-ex-log](https://cloud.githubusercontent.com/assets/12382656/25670096/45c018d0-3034-11e7-936a-f82037ebdf2f.png)