### PR TITLE
Add launch name config option and tags for test items

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,11 @@ The following parapmeters are optional:
 - :code:`rp_launch_description = 'Smoke test'` - launch description
 
 
-Logging
-~~~~~~~
+Examples
+~~~~~~~~
 
 For logging of the test item flow to Report Portal, please, use the python
-logging handler privided by plugin like bellow:
+logging handler provided by plugin like bellow:
 
 .. code-block:: python
 
@@ -101,6 +101,28 @@ logging handler privided by plugin like bellow:
 
         # This debug message will not be sent to the Report Portal.
         logger.debug("Case1. Debug message")
+
+Plugin can report doc-strings of tests as :code:`descriptions`:
+
+.. code-block:: python
+
+    def test_one():
+        """
+        Description of the test case which will be sent to Report Portal
+        """
+        pass
+
+Pytest markers will be attached as :code:`tags` to Report Portal items.
+In the following example tags 'linux' and 'win32' will be used:
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.win32
+    @pytest.mark.linux
+    def test_one():
+        pass
 
 
 Launching

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ any one using pytest command line option:
 
 The :code:`pytest.ini` file should have next mandatory fields:
 
-- :code:`rp_uuid` - number could be found in the User profile section
+- :code:`rp_uuid` - value could be found in the User Profile section
 - :code:`rp_project` - name of project in Report Potal
 - :code:`rp_endpoint` - address of Report Portal Server
 
@@ -45,10 +45,16 @@ Example of :code:`pytest.ini`:
     rp_uuid = fb586627-32be-47dd-93c1-678873458a5f
     rp_endpoint = http://192.168.1.10:8080
     rp_project = user_personal
+    rp_launch = AnyLaunchName
     rp_launch_tags = 'PyTest' 'Smoke'
+    rp_launch_description = 'Smoke test'
 
-Also launch tags could be added, but this parapmeter is not
-mandatory :code:`rp_launch_tags = 'PyTest' 'Report_Portal'`.
+The following parapmeters are optional:
+
+- :code:`rp_launch = AnyLaunchName` - launch name (could be overriden
+  by pytest --rp-launch option, default value is 'Pytest Launch')
+- :code:`rp_launch_tags = 'PyTest' 'Smoke'` - list of tags
+- :code:`rp_launch_description = 'Smoke test'` - launch description
 
 
 Logging
@@ -100,7 +106,7 @@ logging handler privided by plugin like bellow:
 Launching
 ~~~~~~~~~
 
-To run test with Report Portal you need to specify neme of :code:`launch`:
+To run test with Report Portal you can specify name of :code:`launch`:
 
 .. code-block:: bash
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -29,7 +29,6 @@ class RP_Report_Listener(object):
             )
 
         if report.when == "setup":
-
             # when function pytest_setup is called,
             # test item session will be started in RP
             PyTestService.start_pytest_item(item)

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -3,6 +3,7 @@ import traceback
 from time import time
 
 from six import with_metaclass
+from _pytest.mark import MarkMapping
 
 from reportportal_client import ReportPortalServiceAsync
 
@@ -76,10 +77,14 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         except AttributeError:
             # doctest has no `function` attribute
             item_description = test_item.reportinfo()[2]
+
+        # extract names of @pytest.mark.* decorators used for test item
+        item_tags = list(MarkMapping(test_item.keywords)._mymarks)
+
         start_rq = {
             "name": test_item.name,
             "description": item_description,
-            "tags": ['PyTest Item Tag'],
+            "tags": item_tags,
             "start_time": timestamp(),
             "item_type": "TEST"
         }

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -53,13 +53,13 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
             self.RP.terminate()
 
     def start_launch(
-            self, launch_name, mode=None, tags=None):
+            self, launch_name, mode=None, tags=None, description=None):
         # In next versions launch object(suite, testcase)
         # could be set as parameter
         sl_pt = {
             "name": launch_name,
             "start_time": timestamp(),
-            "description": 'Pytest Launch',
+            "description": description,
             "mode": mode,
             "tags": tags
         }

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 setup(
     name="pytest-reportportal",
     version=version,
-    description="Agent for Reproting results of tests to the Report Portal server",
+    description="Agent for Reporting results of tests to the Report Portal server",
     long_description=read_file("README.rst") + "\n\n",
     author="Pavel Papou",
     author_email="SupportEPMC-TSTReportPortal@epam.com",


### PR DESCRIPTION
Changes:
- added rp_launch and rp_launch_description config options;
- rp_launch option has a default value so it is no longer mandatory;
- CLI option --rp_launch will override rp_launch config option;
- updated help strings for options and README file;
- extract names of Pytest markers (decorators like @pytest.mark.linux, @pytest.mark.win32 etc) and use them as Tags for Items on Report Portal;
- Add descriptions and tags usage examples to README.