### PR TITLE
Enhance traceback printing and readme file.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,9 @@ Example of :code:`pytest.ini`:
     rp_launch_description = 'Smoke test'
     rp_ignore_errors = True
 
-The following parapmeters are optional:
+The following parameters are optional:
 
-- :code:`rp_launch = AnyLaunchName` - launch name (could be overriden
+- :code:`rp_launch = AnyLaunchName` - launch name (could be overridden
   by pytest --rp-launch option, default value is 'Pytest Launch')
 - :code:`rp_launch_tags = 'PyTest' 'Smoke'` - list of tags
 - :code:`rp_launch_description = 'Smoke test'` - launch description
@@ -136,6 +136,27 @@ To run test with Report Portal you can specify name of :code:`launch`:
 .. code-block:: bash
 
     py.test ./tests --rp-launch AnyLaunchName
+
+
+Troubleshooting
+~~~~~~~~~
+
+In case you have connectivity issues (or similar problems) with Report Portal,
+it is possible to ignore exception raised by :code:`pytest_reportportal` plugin.
+For this, please, add following option to :code:`pytest.ini` configuration file:
+
+.. code-block:: text
+
+    [pytest]
+    ...
+    rp_ignore_errors = True
+
+
+Or temporary disable :code:`pytest_reportportal` plugin with command like:
+
+.. code-block:: bash
+
+    py.test -p no:pytest_reportportal ./tests
 
 
 Copyright Notice

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -60,9 +60,9 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
     def _stop_if_neccessary(self):
         try:
             exc, msg, tb = self._errors.get(False)
-            traceback.print_exception(exc, msg, tb)
+            err = traceback.format_exception(exc, msg, tb)
             if not self.ignore_errors:
-                pytest.exit(msg)
+                pytest.exit("".join(err))
         except queue.Empty:
             pass
 

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import traceback
 from time import time
 
@@ -60,9 +61,10 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
     def _stop_if_neccessary(self):
         try:
             exc, msg, tb = self._errors.get(False)
-            err = traceback.format_exception(exc, msg, tb)
+            traceback.print_exception(exc, msg, tb)
+            sys.stderr.flush()
             if not self.ignore_errors:
-                pytest.exit("".join(err))
+                pytest.exit(msg)
         except queue.Empty:
             pass
 


### PR DESCRIPTION
In some cases there is no traceback printed if there is an issue with Report Portal (e.g. invalid uuid). Only error message appeared.

Also updated readme with some notes about disabling plug-in.