### PR TITLE
Add fix for issue #37

### DIFF
--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -4,7 +4,7 @@ import traceback
 import pytest
 
 from time import time
-from six import with_metaclass
+from six import with_metaclass, iteritems
 from six.moves import queue
 
 from reportportal_client import ReportPortalServiceAsync
@@ -111,12 +111,15 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         # try to extract names of @pytest.mark.* decorators used for test item
         # and exclude those which present in rp_ignore_tags parameter
         mark_plugin = test_item.config.pluginmanager.getplugin('mark')
-        if mark_plugin:
-            keywords = test_item.keywords
-            marks = mark_plugin.MarkMapping(keywords)._mymarks
-            return [m for m in marks if m not in self.ignored_tags]
-        else:
+        if not mark_plugin:
             return []
+
+        mark_names = set()
+        for key, value in iteritems(test_item.keywords):
+            if (isinstance(value, mark_plugin.MarkInfo) or
+                    isinstance(value, mark_plugin.MarkDecorator)):
+                mark_names.add(key)
+        return [m for m in mark_names if m not in self.ignored_tags]
 
     def finish_pytest_item(self, status, issue=None):
         self._stop_if_necessary()


### PR DESCRIPTION
As was noted in the `pytest-dev@python.org` mailing list, 
> `MarkMapping` is only complete enough to fulfill its internal use case.

That is why was decided to duplicate logic of `from_keyword` class method in our plug-in. 
Other solution with checking existence of attributes and parsing `pytest` version looks even worser personally for me. 