### PR TITLE
Raising exception when using 'xdist' plug-in

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -34,6 +34,10 @@ def pytest_configure(config):
     if not config.option.rp_launch:
         config.option.rp_launch = config.getini('rp_launch')
 
+    if config.pluginmanager.hasplugin('xdist'):
+        raise Exception(
+            "pytest report portal is not compatible with 'xdist' plugin.")
+
     # set Pytest_Reporter and configure it
     config._reporter = RPReportListener()
 


### PR DESCRIPTION
This adds workaround for issue #29 till full architecture re-implementation.
Current implementation of Report Portal `pytest` agent is not compatible with distributed tests execution.
Thus, following workaround has been added to notify end user about this problem.
User will get exception in case when plug-in `xdist` is installed  with output like:
```bash
 $ pytest -n 4 --rp-launch TestRPIssue29 test_script.py
...
INTERNALERROR> Exception: pytest report portal is not compatible with 'xdist' plugin.
```
If it is required to have this plug-in installed for e.g. `unittest`, this plug-in can be temporary disabled for test which running with Repor Portal integration:
```bash
$ pytest -p no:xdist --rp-launch TestRPIssue29 test_script.py
```