### PR TITLE
Fix case of incorrect status when test was skipped in setup.

### DIFF
--- a/pytest_reportportal/listener.py
+++ b/pytest_reportportal/listener.py
@@ -46,6 +46,7 @@ class RPReportListener(object):
             )
 
         if report.when == 'setup':
+            self.result = None
             if report.failed:
                 # This happens for example when a fixture fails to run
                 # causing the test to error


### PR DESCRIPTION
When some test was skipped in the setup, RP wrongly identified its
status, by assigning to it the status of the last non-skipped test.

Test to reproduce:

```
import pytest

@pytest.fixture
def skip_in_setup():
    pytest.skip()

def test_that_fails():
    assert False

@pytest.mark.usefixtures("skip_in_setup")
def test_skip_in_setup(self):
    pass
```

In this example the first test fails and the second is skipped.
RP identified both as failures.