### PR TITLE
Fix log_level evaluation. Fix and simplify logging filtering.

### DIFF
--- a/pytest_reportportal/listener.py
+++ b/pytest_reportportal/listener.py
@@ -13,7 +13,9 @@ except ImportError:
 
 
 class RPReportListener(object):
-    def __init__(self, py_test_service, log_level=logging.NOTSET):
+    def __init__(self, py_test_service,
+                 log_level=logging.NOTSET,
+                 endpoint=None):
         # Test Item result
         self.PyTestService = py_test_service
         self.result = None
@@ -21,7 +23,8 @@ class RPReportListener(object):
         if PYTEST_HAS_LOGGING_PLUGIN:
             self._log_handler = RPLogHandler(py_test_service=py_test_service,
                                              level=log_level,
-                                             filter_reportportal_client_logs=True)
+                                             filter_reportportal_client_logs=True,
+                                             endpoint=endpoint)
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item):

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -104,19 +104,17 @@ def pytest_configure(config):
         config.py_test_service.RP.listener.start()
 
     # set Pytest_Reporter and configure it
-
     if PYTEST_HAS_LOGGING_PLUGIN:
         # This check can go away once we support pytest >= 3.3
-        try:
-            config._reporter = RPReportListener(
-                config.py_test_service,
-                _pytest.logging.get_actual_log_level(config, 'rp_log_level')
-            )
-        except TypeError:
-            # No log level set either in INI or CLI
-            config._reporter = RPReportListener(config.py_test_service)
+        log_level = _pytest.logging.get_actual_log_level(config, 'rp_log_level')
+        if log_level is None:
+            log_level = logging.NOTSET
     else:
-        config._reporter = RPReportListener(config.py_test_service)
+        log_level = logging.NOTSET
+
+    config._reporter = RPReportListener(config.py_test_service,
+                                        log_level=log_level,
+                                        endpoint=endpoint)
 
     if hasattr(config, '_reporter'):
         config.pluginmanager.register(config._reporter)
@@ -153,12 +151,12 @@ def pytest_addoption(parser):
         group.addoption(
             '--rp-log-level',
             dest='rp_log_level',
-            default=logging.NOTSET,
+            default=None,
             help='Logging level for automated log records reporting'
         )
         parser.addini(
             'rp_log_level',
-            default=logging.NOTSET,
+            default=None,
             help='Logging level for automated log records reporting'
         )
 


### PR DESCRIPTION
* Fix log level evaluation. Both option and INI setting must default to None.
* Filter out log messages from `urllib3.connectionpool` if the value of `rp_entpoint` is in the log string