### PR TITLE
use config.option attribute to get rp_launch_description value instea…

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -56,7 +56,7 @@ def pytest_sessionstart(session):
         session.config.py_test_service.start_launch(
             session.config.option.rp_launch,
             tags=session.config.getini('rp_launch_tags'),
-            description=session.config.getini('rp_launch_description'),
+            description=session.config.option.rp_launch_description
         )
         if session.config.pluginmanager.hasplugin('xdist'):
             wait_launch(session.config.py_test_service.RP.rp_client)


### PR DESCRIPTION
While using this plugin I noticed it always uses `launch_description` property as defined in `pytest.ini` file, and one isn't able to override it from command line option as described in documentation.

Seems the reason is `PyTestServiceClass.start_launch` method in `pytest_sessionstart` hook is called with description value retrieved from `session.config.getini`, and command line argument is always ignored.

Changed this line to use `session.config.option` attribute.

Fix tested on my setup, doesn't seem to broke something.