### PR TITLE
Fix for double patching logger class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ in conftest.py:
 
 .. code-block:: python
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture(scope="session")
     def rp_logger(request):
         import logging
         # Import Report Portal logger and handler to the test module.
@@ -86,8 +86,6 @@ in conftest.py:
         rp_handler = RPLogHandler(request.node.config.py_test_service)
         # Set INFO level for Report Portal handler.
         rp_handler.setLevel(logging.INFO)
-        # Add handler to the logger.
-        logger.addHandler(rp_handler)
         return logger
 
 in tests:

--- a/pytest_reportportal/rp_logging.py
+++ b/pytest_reportportal/rp_logging.py
@@ -141,8 +141,10 @@ def patching_logger_class():
                 return record
             return makeRecord
 
-        logger_class._log = wrap_log(logger_class._log)
-        logger_class.makeRecord = wrap_makeRecord(logger_class.makeRecord)
+        if not hasattr(logger_class, "_patched"):
+            logger_class._log = wrap_log(logger_class._log)
+            logger_class.makeRecord = wrap_makeRecord(logger_class.makeRecord)
+            logger_class._patched = True
 
         yield
 


### PR DESCRIPTION
- adding check for logging class patching to avoid double patching. Fix #70
- changes in readme file example: fixture scope was changed to "session" and adding handler to logger was removed