### PR TITLE
New report hierarchy abilities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,11 @@ The following parameters are optional:
 - :code:`rp_log_batch_size = 20` - size of batch log request
 - :code:`rp_ignore_errors = True` - Ignore Report Portal errors (exit otherwise)
 - :code:`rp_ignore_tags = 'xfail' 'usefixture'` - Ignore specified pytest markers
+- :code:`rp_hierarchy_dirs = True` - Enables hierarchy for tests directories (default False)
+- :code:`rp_hierarchy_module = True` - Enables hierarchy for module (default True)
+- :code:`rp_hierarchy_class = True` - Enables hierarchy for class (default True)
+- :code:`rp_hierarchy_parametrize = True` - Enables hierarchy parametrized tests (default False)
+- :code:`rp_hierarchy_dirs_level = 0` - Directory starting hierarchy level (from pytest.ini level) (default 0)
 
 
 Examples

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -246,3 +246,32 @@ def pytest_addoption(parser):
         'rp_ignore_tags',
         type='args',
         help='Ignore specified pytest markers, i.e parametrize')
+
+    parser.addini(
+        'rp_hierarchy_dirs_level',
+        default=0,
+        help='Directory starting hierarchy level')
+
+    parser.addini(
+        'rp_hierarchy_dirs',
+        default=False,
+        type='bool',
+        help='Enables hierarchy for directories')
+
+    parser.addini(
+        'rp_hierarchy_module',
+        default=True,
+        type='bool',
+        help='Enables hierarchy for module')
+
+    parser.addini(
+        'rp_hierarchy_class',
+        default=True,
+        type='bool',
+        help='Enables hierarchy for class')
+
+    parser.addini(
+        'rp_hierarchy_parametrize',
+        default=False,
+        type='bool',
+        help='Enables hierarchy for parametrized tests')


### PR DESCRIPTION
- new hierarchy levels for module directories and parametrized tests;
- ability to configure report hierarchy via pytest.ini;
- generating hierarchy item name depends on configuration;
- hierarchy item result now depends on nested tests results.

Example
dir1/dir2/module1.py::TestClass1::test1 [param1=1]
dir1/dir2/module1.py::TestClass1::test1 [param1=2]
dir1/dir2/module1.py::TestClass1::test2
```
for: hier_dir =1, hier_module=1, hier_class=1, hier_param=0, hier_dir_level=0
we report: dir1 -> dir2 -> module1.py -> TestClass1 -> test1 [param1=1]
                                                                                 -> test1 [param1=2]
                                                                                 -> test2

for: hier_dir =1, hier_module=1, hier_class=1, hier_param=0, hier_dir_level=1
we report: dir2 -> module1.py -> TestClass1 -> test1 [param1=1]
                                                                      -> test1 [param1=2]
                                                                     -> test2

for: hier_dir =0, hier_module=1, hier_class=1, hier_param=0, hier_dir_level=0
we report: dir1/dir2/module1.py -> TestClass1 -> test1 [param1=1]
                                                                        -> test1 [param1=2]
                                                                        -> test2

for: hier_dir =0, hier_module=1, hier_class=1, hier_param=0, hier_dir_level=1
we report: dir2/module1.py -> TestClass1 -> test1 [param1=1]
                                                                 -> test1 [param1=2]
                                                                 -> test2

for: hier_dir =1, hier_module=0, hier_class=0, hier_param=0, hier_dir_level=0
we report: dir1 -> dir2 -> module1.py::TestClass1::test1 [param1=1]
                                    -> module1.py::TestClass1::test1 [param1=2]
                                    -> module1.py::TestClass1::test2


for: hier_dir =1, hier_module=0, hier_class=0, hier_param=1, hier_dir_level=0
we report: dir1 -> dir2 -> module1.py::TestClass1::test1 -> test1 [param1=1]
                                                                                      -> test1 [param1=2]
                                    -> module1.py::TestClass1::test2
```