### PR TITLE
Removing docstring indentations and adding tags for each items in the launch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,8 @@ The following parameters are optional:
 
 - :code:`rp_launch = AnyLaunchName` - launch name (could be overridden
   by pytest --rp-launch option, default value is 'Pytest Launch')
-- :code:`rp_launch_tags = 'PyTest' 'Smoke'` - list of tags
+- :code:`rp_launch_tags = 'PyTest' 'Smoke'` - list of tags for launch
+- :code:`rp_tests_tags = 'PyTest' 'Smoke'` - list of tags that will be added for each item in the launch
 - :code:`rp_launch_description = 'Smoke test'` - launch description (could be overridden
   by pytest --rp-launch-description option, default value is '')
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -227,6 +227,11 @@ def pytest_addoption(parser):
         help='Launch tags, i.e Performance Regression')
 
     parser.addini(
+        'rp_tests_tags',
+        type='args',
+        help='Tags for all tests items, e.g. Smoke')
+
+    parser.addini(
         'rp_launch_description',
         default='',
         help='Launch description')

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -21,6 +21,32 @@ def timestamp():
     return str(int(time() * 1000))
 
 
+def trim_docstring(docstring):
+    if not docstring:
+        return ''
+    # Convert tabs to spaces (following the normal Python rules)
+    # and split into a list of lines:
+    lines = docstring.expandtabs().splitlines()
+    # Determine minimum indentation (first line doesn't count):
+    indent = sys.maxsize
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            indent = min(indent, len(line) - len(stripped))
+    # Remove indentation (first line is special):
+    trimmed = [lines[0].strip()]
+    if indent < sys.maxsize:
+        for line in lines[1:]:
+            trimmed.append(line[indent:].rstrip())
+    # Strip off trailing and leading blank lines:
+    while trimmed and not trimmed[-1]:
+        trimmed.pop()
+    while trimmed and not trimmed[0]:
+        trimmed.pop(0)
+    # Return a single string:
+    return '\n'.join(trimmed)
+
+
 class Singleton(type):
     _instances = {}
 
@@ -385,8 +411,13 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
     def _get_item_tags(self, item):
         # Try to extract names of @pytest.mark.* decorators used for test item
         # and exclude those which present in rp_ignore_tags parameter
-        return [k for k in item.keywords if item.get_marker(k) is not None
+        #return [k for k in item.keywords if item.get_marker(k) is not None
+        #        and k not in self.ignored_tags]
+        tags = [k for k in item.keywords if item.get_marker(k) is not None
                 and k not in self.ignored_tags]
+        tags.extend(item.session.config.getini('rp_tests_tags'))
+
+        return tags
 
     def _get_parameters(self, item):
         return item.callspec.params if hasattr(item, 'callspec') else {}
@@ -408,6 +439,6 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         if isinstance(test_item, (Class, Function, Module, Item)):
             doc = test_item.obj.__doc__
             if doc is not None:
-                return doc.strip()
+                return trim_docstring(doc)
         if isinstance(test_item, DoctestItem):
             return test_item.reportinfo()[2]


### PR DESCRIPTION
- Adding new pytest ini option `rp_tests_tags`, to add tags for each items in the launch
- Removing docstring indentations for item description (see https://www.python.org/dev/peps/pep-0257/)

Previous docstring format:
![image](https://user-images.githubusercontent.com/35855157/45076937-a2f4ac80-b0a0-11e8-9826-392e0ad71a82.png)

New docstring format:
![image](https://user-images.githubusercontent.com/35855157/45076969-bf90e480-b0a0-11e8-8fa3-76cb94cf46db.png)