### PR TITLE
fixed the attribute name _reportportal_enabled to _reportportal_configured

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -29,7 +29,7 @@ def is_master(config):
 
 @pytest.mark.optionalhook
 def pytest_configure_node(node):
-    if node.config._reportportal_enabled is False:
+    if node.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
         return
     node.slaveinput['py_test_service'] = pickle.dumps(node.config.py_test_service)


### PR DESCRIPTION
i believe there is a bug: 
https://github.com/reportportal/agent-python-pytest/issues/80#issuecomment-417326908

and this should fix it