### PR TITLE
Add ignore ssl rules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ The following parameters are optional:
 - :code:`rp_hierarchy_class = True` - Enables hierarchy for class, default `True`. Doesn't support 'xdist' plugin.
 - :code:`rp_hierarchy_parametrize = True` - Enables hierarchy parametrized tests, default `False`. Doesn't support 'xdist' plugin.
 - :code:`rp_hierarchy_dirs_level = 0` - Directory starting hierarchy level (from pytest.ini level) (default `0`)
+- :code:`rp_ignore_ssl = False` - Ignore SSL Errors when connecting to the server
 
 
 Examples

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ The following parameters are optional:
 - :code:`rp_hierarchy_class = True` - Enables hierarchy for class, default `True`. Doesn't support 'xdist' plugin.
 - :code:`rp_hierarchy_parametrize = True` - Enables hierarchy parametrized tests, default `False`. Doesn't support 'xdist' plugin.
 - :code:`rp_hierarchy_dirs_level = 0` - Directory starting hierarchy level (from pytest.ini level) (default `0`)
-- :code:`rp_ignore_ssl = False` - Ignore SSL Errors when connecting to the server
+- :code:`rp_verify_ssl = True` - Verify SSL when connecting to the server
 
 
 Examples

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -46,6 +46,8 @@ def pytest_sessionstart(session):
     if not session.config.option.rp_enabled:
         return
 
+    verify_ssl = not session.config.getini('rp_ignore_ssl')
+
     if is_master(session.config):
         session.config.py_test_service.init_service(
             project=session.config.getini('rp_project'),
@@ -54,6 +56,7 @@ def pytest_sessionstart(session):
             log_batch_size=int(session.config.getini('rp_log_batch_size')),
             ignore_errors=bool(session.config.getini('rp_ignore_errors')),
             ignored_tags=session.config.getini('rp_ignore_tags'),
+            verify_ssl=verify_ssl
         )
 
         session.config.py_test_service.start_launch(
@@ -279,3 +282,9 @@ def pytest_addoption(parser):
         default=False,
         type='bool',
         help='Enables hierarchy for parametrized tests')
+
+    parser.addini(
+        'rp_ignore_ssl',
+        default=False,
+        type='bool',
+        help='Ignores ssl errors')

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -46,8 +46,6 @@ def pytest_sessionstart(session):
     if not session.config.option.rp_enabled:
         return
 
-    verify_ssl = not session.config.getini('rp_ignore_ssl')
-
     if is_master(session.config):
         session.config.py_test_service.init_service(
             project=session.config.getini('rp_project'),
@@ -56,7 +54,7 @@ def pytest_sessionstart(session):
             log_batch_size=int(session.config.getini('rp_log_batch_size')),
             ignore_errors=bool(session.config.getini('rp_ignore_errors')),
             ignored_tags=session.config.getini('rp_ignore_tags'),
-            verify_ssl=verify_ssl
+            verify_ssl=session.config.getini('rp_verify_ssl')
         )
 
         session.config.py_test_service.start_launch(
@@ -284,7 +282,7 @@ def pytest_addoption(parser):
         help='Enables hierarchy for parametrized tests')
 
     parser.addini(
-        'rp_ignore_ssl',
-        default=False,
+        'rp_verify_ssl',
+        default=True,
         type='bool',
-        help='Ignores ssl errors')
+        help='Verify HTTPS calls')

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -77,7 +77,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         self._item_parts = {}
 
     def init_service(self, endpoint, project, uuid, log_batch_size,
-                     ignore_errors, ignored_tags):
+                     ignore_errors, ignored_tags, verify_ssl=True):
         self._errors = queue.Queue()
         if self.RP is None:
             self.ignore_errors = ignore_errors
@@ -92,7 +92,8 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 project=project,
                 token=uuid,
                 error_handler=self.async_error_handler,
-                log_batch_size=log_batch_size
+                log_batch_size=log_batch_size,
+                verify_ssl=verify_ssl
             )
         else:
             log.debug('The pytest is already initialized')


### PR DESCRIPTION
This builds on https://github.com/reportportal/client-Python/pull/33 to add an `verify_ssl` option to the pytest ini file. This allows the library to be used with self signed certs without having to add the cert to requests

Edit: `ignore_ssl` -> `verify_ssl`