### PR TITLE
record.attachment overwritten by None value

### DIFF
--- a/pytest_reportportal/rp_logging.py
+++ b/pytest_reportportal/rp_logging.py
@@ -44,7 +44,8 @@ class RPLogger(logging.getLoggerClass()):
             record = self.makeRecord(self.name, level, fn, lno, msg, args,
                                      exc_info, func, extra, sinfo)
 
-        record.attachment = attachment
+        if not record.attachment:
+            record.attachment = attachment
         self.handle(record)
 
 


### PR DESCRIPTION
I faced with an issue when attachment I send to rp_logger.info was empty in some cases. Going through the code, I noticed that wrap_makeRecord actually handles situations when "attachment" is in the "extra" parameter and then performs record.attachment = attachment (at the end of wrap_makeRecord -> makeRecord method). But when wrapper finishes, right in the next line code overwrites correct value of record.attachment with None value.