### PR TITLE
fix README rendering error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     version=version,
     description='Agent for Reporting results of tests to the Report Portal',
     long_description=read_file('README.rst'),
+    long_description_content_type='text/markdown',
     author='Pavel Papou',
     author_email='SupportEPMC-TSTReportPortal@epam.com',
     url='https://github.com/reportportal/agent-python-pytest',


### PR DESCRIPTION
Fix for "HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText" (Jenkins [console](http://jenkins.epm-rpp.projects.epam.com:8181/job/agent-python-pytest/18/console))