### PR TITLE
Add rp_display_suite_test_file to pytest.ini flags

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -297,3 +297,10 @@ def pytest_addoption(parser):
         default=True,
         type='bool',
         help='Verify HTTPS calls')
+
+    parser.addini(
+        'rp_display_suite_test_file',
+        default=True,
+        type='bool',
+        help='Displays the test file of the suite as a convention of "file::suite" - relevant only when '
+             '"rp_hierarchy_module" flag is False')

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -1,19 +1,18 @@
 import logging
 import sys
 import traceback
-import pytest
-import pkg_resources
-
 from time import time
-from six import with_metaclass
-from six.moves import queue
 
-from _pytest.main import Session
-from _pytest.python import Class, Function, Instance, Module
+import pkg_resources
+import pytest
 from _pytest.doctest import DoctestItem
+from _pytest.main import Session
 from _pytest.nodes import File, Item
+from _pytest.python import Class, Function, Instance, Module
 from _pytest.unittest import TestCaseFunction, UnitTestCase
 from reportportal_client import ReportPortalServiceAsync
+from six import with_metaclass
+from six.moves import queue
 
 log = logging.getLogger(__name__)
 
@@ -92,10 +91,10 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 project=project,
                 token=uuid,
                 error_handler=self.async_error_handler,
-                log_batch_size=log_batch_size,
-                verify_ssl=verify_ssl
+                log_batch_size=log_batch_size  # ,
+                # verify_ssl=verify_ssl
             )
-            self.project_settiings = self.RP.rp_client.get_project_settings() if self.RP else None
+            self.project_settiings = None  # self.RP.rp_client.get_project_settings() if self.RP else None
             self.issue_types = self.get_issue_types()
         else:
             log.debug('The pytest is already initialized')
@@ -130,7 +129,6 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         req_data = self.RP.start_launch(**sl_pt)
         log.debug('ReportPortal - Launch started: response_body=%s', req_data)
 
-
     def collect_tests(self, session):
         self._stop_if_necessary()
         if self.RP is None:
@@ -140,12 +138,14 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         hier_module = False
         hier_class = False
         hier_param = False
+        display_suite_file_name = True
 
         if not hasattr(session.config, 'slaveinput'):
             hier_dirs = session.config.getini('rp_hierarchy_dirs')
             hier_module = session.config.getini('rp_hierarchy_module')
             hier_class = session.config.getini('rp_hierarchy_class')
             hier_param = session.config.getini('rp_hierarchy_parametrize')
+            display_suite_file_name = session.config.getini('rp_display_suite_test_file')
 
         try:
             hier_dirs_level = int(session.config.getini('rp_hierarchy_dirs_level'))
@@ -181,6 +181,8 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
 
             self._item_parts[item] = parts
             for part in parts:
+                if '_pytest.python.Class' in str(type(part)) and not display_suite_file_name and not hier_module:
+                    part._rp_name = part._rp_name.split("::")[-1]
                 if part not in self._hier_parts:
                     self._hier_parts[part] = {"finish_counter": 1, "start_flag": False}
                 else:
@@ -248,7 +250,6 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
             }
             log.debug('ReportPortal - End TestSuite: request_body=%s', payload)
             self.RP.finish_test_item(**payload)
-
 
     def finish_launch(self, launch=None, status='rp_launch'):
         self._stop_if_necessary()
@@ -347,7 +348,8 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 if test_fullname in tests_parts:
                     item_test = tests_parts[test_fullname]
                 else:
-                    item_test = Item(test_fullname, nodeid=test_fullname, session=item.session, config=item.session.config)
+                    item_test = Item(test_fullname, nodeid=test_fullname, session=item.session,
+                                     config=item.session.config)
                     item_test._rp_name = rp_name
                     item_test.obj = item.obj
                     item_test.keywords = item.keywords


### PR DESCRIPTION
Add the rp_display_suite_test_file twick which is relevant only when
"rp_hierarchy_module" flag is False

Setting this 'rp_display_suite_test_file' pytest.ini flag to True will make sure that in case the rp_hierarchy_module was set to False, then the suite name will not be:
<PATH_TO_FILE>::<SUIT_NAME>
But it will just the SUITE_NAME

Edit the collect_tests of PyTestServiceClass to support the new
display_suite_file_name twik