### PR TITLE
eden/fix_pytest_mark_issue_functionality branch PR

### DIFF
--- a/pytest_reportportal/listener.py
+++ b/pytest_reportportal/listener.py
@@ -59,7 +59,7 @@ class RPReportListener(object):
                 # causing the test to error
                 self.result = 'FAILED'
                 self._add_issue_info(item, report)
-            elif report.skipped:
+            elif report.skipped or item.get_marker('issue'):
                 # This happens when a testcase is marked "skip".  It will
                 # show in reportportal as not requiring investigation.
                 self.result = 'SKIPPED'
@@ -68,7 +68,7 @@ class RPReportListener(object):
         if report.when == 'call':
             if report.passed:
                 item_result = 'PASSED'
-            elif report.skipped:
+            elif report.skipped or item.get_marker('issue'):
                 item_result = 'SKIPPED'
                 self._add_issue_info(item, report)
             else:
@@ -105,8 +105,7 @@ class RPReportListener(object):
                     for issue_id in issue_ids:
                         comment += " [{}]({}{})".format(issue_id, url, issue_id) if url else " {}".format(issue_id)
 
-                if "issue_type" in mark.kwargs:
-                    issue_type = mark.kwargs["issue_type"]
+                issue_type = mark.kwargs.get("issue_type", "PB").upper()
 
         if comment:
             self.issue['comment'] = comment

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -61,6 +61,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
 
     def __init__(self):
         self.RP = None
+        self.issue_types = {}
         try:
             pkg_resources.get_distribution('reportportal_client >= 3.2.0')
             self.RP_SUPPORTS_PARAMETERS = True
@@ -292,15 +293,10 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         except queue.Empty:
             pass
 
-    def get_issue_types(self):
-        issue_types = {}
-        if not self.project_settiings:
-            return issue_types
-
-        for item_type in ("AUTOMATION_BUG", "PRODUCT_BUG", "SYSTEM_ISSUE", "NO_DEFECT", "TO_INVESTIGATE"):
-            for item in self.project_settiings["subTypes"][item_type]:
-                issue_types[item["shortName"]] = item["locator"]
-
+    @staticmethod
+    def get_issue_types():
+        issue_types = {"PB": "PRODUCT_BUG", "AB": "AUTOMATION_BUG", "SI": "SYSTEM_ISSUE", "ND": "NO_DEFECT",
+                       "TI": "TO_INVESTIGATE"}
         return issue_types
 
     @staticmethod


### PR DESCRIPTION
Fix the @pytest.mark.issue functionality

This PR fixes the following exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reportportal_client/service_async.py", line 208, in process_item
    getattr(self.rp_client, method)(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/reportportal_client/service.py", line 199, in finish_test_item
    return _get_msg(r)
  File "/usr/local/lib/python3.6/site-packages/reportportal_client/service.py", line 22, in _get_msg
    return _get_data(response)["msg"]
  File "/usr/local/lib/python3.6/site-packages/reportportal_client/service.py", line 34, in _get_data
    raise ResponseError(error_messages[0])
reportportal_client.errors.ResponseError: 4001: Incorrect Request. [Field 'issue.issueType' shouldn't be null.] 
```