### PR TITLE
Fixes for fail on empty issue type and disabling quotes escaping

### DIFF
--- a/pytest_reportportal/listener.py
+++ b/pytest_reportportal/listener.py
@@ -49,7 +49,7 @@ class RPReportListener(object):
 
         if report.longrepr:
             self.PyTestService.post_log(
-                escape(report.longreprtext),
+                escape(report.longreprtext, False),
                 loglevel='ERROR',
             )
 
@@ -109,6 +109,8 @@ class RPReportListener(object):
 
                 if "issue_type" in mark.kwargs:
                     issue_type = mark.kwargs["issue_type"]
+
+        issue_type = "TI" if issue_type is None else issue_type
 
         if issue_type and self.PyTestService.issue_types \
                 and (issue_type in self.PyTestService.issue_types):

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -98,9 +98,9 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 # verify_ssl=verify_ssl
             )
             if self.RP and hasattr(self.RP.rp_client, "get_project_settings"):
-                self.project_settiings = self.RP.rp_client.get_project_settings()
+                self.project_settings = self.RP.rp_client.get_project_settings()
             else:
-                self.project_settiings = None
+                self.project_settings = None
             self.issue_types = self.get_issue_types()
         else:
             log.debug('The pytest is already initialized')
@@ -300,11 +300,11 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
 
     def get_issue_types(self):
         issue_types = {}
-        if not self.project_settiings:
+        if not self.project_settings:
             return issue_types
 
         for item_type in ("AUTOMATION_BUG", "PRODUCT_BUG", "SYSTEM_ISSUE", "NO_DEFECT", "TO_INVESTIGATE"):
-            for item in self.project_settiings["subTypes"][item_type]:
+            for item in self.project_settings["subTypes"][item_type]:
                 issue_types[item["shortName"]] = item["locator"]
 
         return issue_types


### PR DESCRIPTION
- Fix exception on empty issue type:
```
reportportal_client.errors.ResponseError: 4001: Incorrect Request. [Field 'issue.issueType' shouldn't be null.]
```
- Disabling escaping for quotes in logs:
Compare:
`[&#x27;special-vector&#x27;, &#x27;packet-types&#x27;, &#x27;no-per-ip&#x27;];`
and:
`['special-vector', 'packet-types', 'no-per-ip']`
- fix for typo in `service.project_settiings`


