### PR TITLE
Stop plugin configuration if ReportPortal connection fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "3.5"
   - "3.6"
 script:
+  - python setup.py test
   - python setup.py -q install
 
 jobs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [metadata]
 description-file = README.rst
 
@@ -6,3 +9,6 @@ formats=gztar
 
 [bdist_wheel]
 universal = 1
+
+[tool:pytest]
+addopts=-vv

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tar_url = 'https://github.com/reportportal/agent-python-pytest/tarball/1.0.3'
 
 
 requirements = [
-    'reportportal-client>=3.1.0',
+    'reportportal-client>=3.2.3',
     'pytest>=3.0.7',
     'six>=1.10.0',
     'dill>=0.2.7.1',
@@ -46,4 +46,9 @@ setup(
             'pytest_reportportal = pytest_reportportal.plugin',
         ]
     },
+    setup_requires=['pytest-runner'],
+    tests_require=[
+        'pytest',
+        'delayed-assert'
+    ]
 )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,33 @@
+"""This modules includes unit tests for the plugin."""
+
+from requests.exceptions import RequestException
+try:
+    from unittest.mock import create_autospec, Mock, patch
+except ImportError:
+    from mock import create_autospec, Mock, patch
+
+from _pytest.config import Config
+from  delayed_assert import expect, assert_expectations
+
+from pytest_reportportal.plugin import pytest_configure
+
+
+@patch('pytest_reportportal.plugin.requests.get')
+def test_stop_plugin_configuration_on_conn_error(mocked_get):
+    """Test plugin configuration in case of HTTP error.
+
+    The value of the _reportportal_configured attribute of the pytest Config
+    object should be change to False, stopping plugin configuration, if HTTP
+    error occurs getting HTTP response from the ReportPortal.
+    :param mocked_get: Instance of the MagicMock
+    """
+    mocked_config = create_autospec(Config)
+    mocked_config.return_value._reportportal_configured = True
+    mock_response = Mock()
+    mock_response.raise_for_status.side_effect = RequestException()
+    mocked_get.return_value = mock_response
+    expect(pytest_configure(mocked_config) is None,
+           'Received unexpected return value from pytest_configure.')
+    expect(mocked_config._reportportal_configured is False,
+           'The value of the _reportportal_configured is not False.')
+    assert_expectations()


### PR DESCRIPTION
This is an improved version of https://github.com/reportportal/agent-python-pytest/pull/100 with unit tests.