### PR TITLE
Update an example of the python logging handler usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 stages:
 - test
 - name: deploy
-  if: tag IS present
+  if: tag IS present AND fork = false
 language: python
 python:
   - "2.7"

--- a/README.rst
+++ b/README.rst
@@ -97,14 +97,18 @@ in conftest.py:
     @pytest.fixture(scope="session")
     def rp_logger(request):
         import logging
-        # Import Report Portal logger and handler to the test module.
-        from pytest_reportportal import RPLogger, RPLogHandler
-        # Setting up a logging.
-        logging.setLoggerClass(RPLogger)
         logger = logging.getLogger(__name__)
         logger.setLevel(logging.DEBUG)
-        # Create handler for Report Portal.
-        rp_handler = RPLogHandler(request.node.config.py_test_service)
+        # Create handler for Report Portal if the service has been
+        # configured and started.
+        if hasattr(request.node.config, 'py_test_service'):
+            # Import Report Portal logger and handler to the test module.
+            from pytest_reportportal import RPLogger, RPLogHandler
+            logging.setLoggerClass(RPLogger)
+            rp_handler = RPLogHandler(request.node.config.py_test_service)
+        else:
+            import sys
+            rp_handler = logging.StreamHandler(sys.stdout)
         # Set INFO level for Report Portal handler.
         rp_handler.setLevel(logging.INFO)
         return logger

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ def read_file(fname):
         return f.read()
 
 
-version = '1.0.5'
-tar_url = 'https://github.com/reportportal/agent-python-pytest/tarball/1.0.3'
+version = '1.0.8'
 
 
 requirements = [
@@ -29,7 +28,6 @@ setup(
     author='Pavel Papou',
     author_email='SupportEPMC-TSTReportPortal@epam.com',
     url='https://github.com/reportportal/agent-python-pytest',
-    download_url=tar_url,
     packages=['pytest_reportportal'],
     install_requires=requirements,
     license='Apache 2.0',


### PR DESCRIPTION
What's in?

1. Bumped the version up to 1.0.8 to align releases at GitHub and version at PyPi.
2. Disable deployment on forks.