### PR TITLE
Fix logging issue and adding support for pytest --setup-plan option

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -37,14 +37,8 @@ def pytest_configure_node(node):
 
 
 def pytest_sessionstart(session):
-    if session.config.getoption('--collect-only', default=False) is True:
-        return
-
     if session.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
-        return
-
-    if not session.config.option.rp_enabled:
         return
 
     if is_master(session.config):
@@ -87,9 +81,6 @@ def pytest_collection_modifyitems(session, config, items):
 
 
 def pytest_collection_finish(session):
-    if session.config.getoption('--collect-only', default=False) is True:
-        return
-
     if session.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
         return
@@ -106,14 +97,8 @@ def wait_launch(rp_client):
 
 
 def pytest_sessionfinish(session):
-    if session.config.getoption('--collect-only', default=False) is True:
-        return
-
     if session.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
-        return
-
-    if not session.config.option.rp_enabled:
         return
 
     # FixMe: currently method of RP api takes the string parameter
@@ -125,6 +110,13 @@ def pytest_sessionfinish(session):
 
 
 def pytest_configure(config):
+
+    if config.getoption('--collect-only', default=False) or \
+            config.getoption('--setup-plan', default=False) or \
+            not config.option.rp_enabled:
+        config._reportportal_configured = False
+        return
+
     project = config.getini('rp_project')
     endpoint = config.getini('rp_endpoint')
     uuid = config.getini('rp_uuid')

--- a/pytest_reportportal/rp_logging.py
+++ b/pytest_reportportal/rp_logging.py
@@ -44,7 +44,7 @@ class RPLogger(logging.getLoggerClass()):
             record = self.makeRecord(self.name, level, fn, lno, msg, args,
                                      exc_info, func, extra, sinfo)
 
-        if not record.attachment:
+        if not getattr(record, 'attachment', None):
             record.attachment = attachment
         self.handle(record)
 


### PR DESCRIPTION
* fix for logger issue:
```
INTERNALERROR>   File "/usr/lib/python3.6/logging/__init__.py", line 1308, in info
INTERNALERROR>     self._log(INFO, msg, args, **kwargs)
INTERNALERROR>   File "/usr/local/lib/python3.6/dist-packages/pytest_reportportal/rp_logging.py", line 48, in _log
INTERNALERROR>     if not record.attachment:
INTERNALERROR> AttributeError: 'LogRecord' object has no attribute 'attachment'
```
* adding support for pytest `--setup-plan` option
* code optimization for `config._reportportal_configured`
