### PR TITLE
pytest 3.8 fix for cgi.escape

### DIFF
--- a/pytest_reportportal/listener.py
+++ b/pytest_reportportal/listener.py
@@ -1,6 +1,7 @@
 import cgi
 import pytest
 import logging
+import html
 
 
 try:
@@ -47,7 +48,7 @@ class RPReportListener(object):
         if report.longrepr:
             self.PyTestService.post_log(
                 # Used for support python 2.7
-                cgi.escape(report.longreprtext),
+                html.escape(report.longreprtext),
                 loglevel='ERROR',
             )
 


### PR DESCRIPTION
As `cgi.escape` was  deprecated in python 3.7, its has been removed in python 3.8 and hence throwing following error:

```
INTERNALERROR>   File "/Users/fnaeem/projects/python/testify/venv3.8/lib/python3.8/site-packages/pytest_reportportal/listener.py", line 50, in pytest_runtest_makereport
INTERNALERROR>     cgi.escape(report.longreprtext),
INTERNALERROR> AttributeError: module 'cgi' has no attribute 'escape'

```

this commit fix this issue.
