### PR TITLE
rp_logging: Remove '_patched' when 'patching_logger_class' finished.

### DIFF
--- a/pytest_reportportal/rp_logging.py
+++ b/pytest_reportportal/rp_logging.py
@@ -149,5 +149,7 @@ def patching_logger_class():
         yield
 
     finally:
-        logger_class._log = original_log
-        logger_class.makeRecord = original_makeRecord
+        if hasattr(logger_class, '_patched'):
+            logger_class._log = original_log
+            logger_class.makeRecord = original_makeRecord
+            del logger_class._patched


### PR DESCRIPTION
Hello, I have the same issue as #70 with curcrent versions: 
pytest                               4.6.6
pytest-reportportal         1.0.8
reportportal-client          3.2.3

The `pytest_runtest_protocol` wrapper in `listener.py` does restore the patching, but doesn't allow re-patching of the logger class.  This patch remove the `_patched` attribute, so the logger class can be patched again.

Thank you!