### PR TITLE
Adding support for issue-id marks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,7 @@ The following parameters are optional:
 - :code:`rp_hierarchy_dirs_level = 0` - Directory starting hierarchy level (from pytest.ini level) (default `0`)
 - :code:`rp_issue_marks = 'xfail' 'issue'` - Pytest marks that could be used to get issue information (id, type, reason)
 - :code:`rp_issue_system_url = http://bugzilla.some.com/show_bug.cgi?id={%issue_id}` - issue URL (issue_id will be filled by parameter from pytest mark)
+- :code:`rp_issue_id_marks = True` - Enables adding marks for issue ids (e.g. "issue:123456")
 - :code:`rp_verify_ssl = True` - Verify SSL when connecting to the server
 - :code:`rp_display_suite_test_file = True` In case of True, include the suite's relative file path in the launch name as a convention of "<RELATIVE_FILE_PATH>::<SUITE_NAME>". In case of False, set the launch name to be the suite name only - this flag is relevant only when "rp_hierarchy_module" flag is set to False
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -318,6 +318,12 @@ def pytest_addoption(parser):
              "only - this flag is relevant only when 'rp_hierarchy_module' flag is set to False")
 
     parser.addini(
+        'rp_issue_id_marks',
+        type='bool',
+        default=True,
+        help='Adding tag with issue id to the test')
+
+    parser.addini(
         'retries',
         default='0',
         help='Amount of retries for performing REST calls to RP server')

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -240,6 +240,31 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         log.debug('ReportPortal - Start TestItem: request_body=%s', start_rq)
         self.RP.start_test_item(**start_rq)
 
+    def is_item_update_supported(self):
+        """Check item update API call client support."""
+        return hasattr(self.RP, "update_test_item")
+
+    def update_pytest_item(self, test_item=None):
+        """Make item update API call.
+
+        :param test_item: pytest test item
+        """
+        self._stop_if_necessary()
+        if self.RP is None:
+            return
+
+        # if update_test_item is not supported in client
+        if not self.is_item_update_supported():
+            log.debug('ReportPortal - Update TestItem: method is not defined')
+            return
+
+        start_rq = {
+            'description': self._get_item_description(test_item),
+            'tags': self._get_item_tags(test_item),
+        }
+        log.debug('ReportPortal - Update TestItem: request_body=%s', start_rq)
+        self.RP.update_test_item(**start_rq)
+
     def finish_pytest_item(self, test_item, status, issue=None):
         self._stop_if_necessary()
         if self.RP is None:


### PR DESCRIPTION
- Adds ability to add issue-id marks (tags) to the test (e.g. issue:23467)
- Support ability to adding item marks inside test or fixture
- Fix issue when teadworn fixture is failed but test result is passed
See also: https://github.com/reportportal/client-Python/pull/63