### PR TITLE
RP v5.0.0 compatability

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -105,8 +105,7 @@ def pytest_sessionfinish(session):
     nowait = True if shouldfail else False
 
     if is_master(session.config):
-        session.config.py_test_service.finish_launch(
-            status='RP_Launch', force=nowait)
+        session.config.py_test_service.finish_launch(force=nowait)
 
     session.config.py_test_service.terminate_service(nowait=nowait)
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -189,7 +189,7 @@ def test_sessionfinish_with_maxfail(shouldfail, outcome):
     mocked_session.config.py_test_service.finish_launch = Mock()
     pytest_sessionfinish(mocked_session)
     expect(lambda: mocked_session.config.py_test_service.
-        finish_launch.assert_called_with(force=outcome, status='RP_Launch'))
+        finish_launch.assert_called_with(force=outcome))
     expect(lambda: mocked_session.config.py_test_service.
         terminate_service.assert_called_with(nowait=outcome))
     assert_expectations()


### PR DESCRIPTION
## Changes

- removed `RP_launch` from status as it's incompatible with endpoint. Seems that this is an invalid status. Not sending any status seems to work just fine.

**Note**: I recommend dropping legacy python support as it EOL and would make the code much easier to manage.
 
Also, I'd consider adding some in integration tests with RP. This could probably be (somewhat) easily achievable via docker containers.

Note that there's are also some changes that are required in https://github.com/reportportal/client-Python, I'll open a PR there too and link it.
