### PR TITLE
Fix reporting of an issue marker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ stages:
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 script:
   - python setup.py test
   - python setup.py -q install

--- a/pytest_reportportal/listener.py
+++ b/pytest_reportportal/listener.py
@@ -150,7 +150,7 @@ class RPReportListener(object):
                 (issue_type in getattr(self.PyTestService, 'issue_types', ())):
             if comment:
                 self.issue['comment'] = comment
-            self.issue['issue_type'] = self.PyTestService.issue_types[issue_type]
+            self.issue['issueType'] = self.PyTestService.issue_types[issue_type]
             # self.issue['ignoreAnalyzer'] = True ???
         elif (report.when == 'setup') and report.skipped:
-            self.issue['issue_type'] = 'NOT_ISSUE'
+            self.issue['issueType'] = 'NOT_ISSUE'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_file(fname):
         return f.read()
 
 
-version = '5.0.0'
+version = '5.0.1'
 
 
 requirements = [
@@ -34,9 +34,10 @@ setup(
     classifiers=[
         'Framework :: Pytest',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
         ],
     entry_points={
         'pytest11': [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+"""This package contains unit tests for the project."""
+
+from six import add_move, MovedModule
+add_move(MovedModule('mock', 'mock', 'unittest.mock'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+"""This module contains common Pytest fixtures and hooks for unit tests."""
+
+from six.moves import mock
+
+from _pytest.config import Config
+from pytest import fixture
+
+from pytest_reportportal import RPLogger
+from pytest_reportportal.listener import RPReportListener
+from pytest_reportportal.service import PyTestServiceClass
+
+
+@fixture
+def logger():
+    """Prepare instance of the RPLogger for testing."""
+    return RPLogger('pytest_reportportal.test')
+
+
+@fixture()
+def mocked_item(mocked_session):
+    """Mock Pytest item for testing."""
+    test_item = mock.Mock()
+    test_item.session = mocked_session
+    return test_item
+
+
+@fixture()
+def mocked_config():
+    """Mock Pytest config for testing."""
+    mocked_config = mock.create_autospec(Config)
+    mocked_config._reportportal_configured = True
+    return mocked_config
+
+
+@fixture()
+def mocked_session(mocked_config):
+    """Mock Pytest session for testing."""
+    mocked_session = mock.Mock()
+    mocked_session.config = mocked_config
+    return mocked_session
+
+
+@fixture(scope='session')
+def rp_listener(rp_service):
+    """Prepare instance of the RPReportListener for testing."""
+    return RPReportListener(rp_service)
+
+
+@fixture(scope='session')
+def rp_service():
+    """Prepare instance of the PyTestServiceClass for testing."""
+    service = PyTestServiceClass()
+    with mock.patch('reportportal_client.service.'
+                    'ReportPortalService.get_project_settings'):
+        service.init_service("endpoint", "project", "uuid", 20, False, [])
+        return service

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,38 +1,26 @@
 """This modules includes unit tests for the plugin."""
 
-try:
-    from unittest.mock import create_autospec, Mock, patch
-except ImportError:
-    from mock import create_autospec, Mock, patch
+from six.moves import mock
 
-from _pytest.config import Config
 from delayed_assert import expect, assert_expectations
 import pytest
 from requests.exceptions import RequestException
 
 from pytest_reportportal.listener import RPReportListener
-from pytest_reportportal.plugin import pytest_configure, pytest_sessionfinish
-from pytest_reportportal.service import PyTestServiceClass
-from pytest_reportportal import RPLogger
+from pytest_reportportal.plugin import pytest_configure
 
 
-@pytest.fixture
-def logger():
-    return RPLogger("pytest_reportportal.test")
-
-
-@patch('pytest_reportportal.plugin.requests.get')
-def test_stop_plugin_configuration_on_conn_error(mocked_get):
+@mock.patch('pytest_reportportal.plugin.requests.get')
+def test_stop_plugin_configuration_on_conn_error(mocked_get, mocked_config):
     """Test plugin configuration in case of HTTP error.
 
     The value of the _reportportal_configured attribute of the pytest Config
-    object should be change to False, stopping plugin configuration, if HTTP
+    object should be changed to False, stopping plugin configuration, if HTTP
     error occurs getting HTTP response from the ReportPortal.
-    :param mocked_get: Instance of the MagicMock
+    :param mocked_get:    Instance of the MagicMock
+    :param mocked_config: Pytest fixture
     """
-    mocked_config = create_autospec(Config)
-    mocked_config.return_value._reportportal_configured = True
-    mock_response = Mock()
+    mock_response = mock.Mock()
     mock_response.raise_for_status.side_effect = RequestException()
     mocked_get.return_value = mock_response
     expect(pytest_configure(mocked_config) is None,
@@ -42,79 +30,83 @@ def test_stop_plugin_configuration_on_conn_error(mocked_get):
     assert_expectations()
 
 
-@patch('pytest_reportportal.RPLogger.handle')
-@pytest.mark.parametrize("log_level", ("info", "debug", "warning", "error"))
+@mock.patch('pytest_reportportal.RPLogger.handle')
+@pytest.mark.parametrize('log_level', ('info', 'debug', 'warning', 'error'))
 def test_logger_handle_attachment(mock_handler, logger, log_level):
     """Test logger call for different log levels with some text attachment."""
     log_call = getattr(logger, log_level)
-    attachment = "Some {} attachment".format(log_level)
+    attachment = 'Some {} attachment'.format(log_level)
     log_call("Some {} message".format(log_level), attachment=attachment)
-    expect(mock_handler.call_count == 1, "logger.handle called more than 1 time")
+    expect(mock_handler.call_count == 1,
+           'logger.handle called more than 1 time')
     expect(getattr(mock_handler.call_args[0][0], "attachment") == attachment,
-           "record.attachment in args doesn't match real value")
+           'record.attachment in args doesn\'t match real value')
     assert_expectations()
 
 
-@patch('pytest_reportportal.RPLogger.handle')
-@pytest.mark.parametrize("log_level", ("info", "debug", "warning", "error"))
+@mock.patch('pytest_reportportal.RPLogger.handle')
+@pytest.mark.parametrize('log_level', ('info', 'debug', 'warning', 'error'))
 def test_logger_handle_no_attachment(mock_handler, logger, log_level):
     """Test logger call for different log levels without any attachment."""
     log_call = getattr(logger, log_level)
-    log_call("Some {} message".format(log_level))
-    expect(mock_handler.call_count == 1, "logger.handle called more than 1 time")
-    expect(getattr(mock_handler.call_args[0][0], "attachment") is None,
-           "record.attachment in args is not None")
+    log_call('Some {} message'.format(log_level))
+    expect(mock_handler.call_count == 1,
+           'logger.handle called more than 1 time')
+    expect(getattr(mock_handler.call_args[0][0], 'attachment') is None,
+           'record.attachment in args is not None')
     assert_expectations()
 
 
-def test_pytest_runtest_protocol(request):
-    """Test listener pytest_runtest_protocol hook."""
-    rp_service = Mock()
-    rp_service.is_item_update_supported = Mock(return_value=False)
-    rp_listener = RPReportListener(rp_service)
-    rp_listener._add_issue_id_marks = Mock()
-    test_item = Mock()
+def test_pytest_runtest_protocol(mocked_item):
+    """Test listener pytest_runtest_protocol hook.
 
-    next(rp_listener.pytest_runtest_protocol(test_item))
+    :param mocked_item: Pytest fixture
+    """
+    rp_service = mock.Mock()
+    rp_service.is_item_update_supported = mock.Mock(return_value=False)
+    rp_listener = RPReportListener(rp_service)
+    rp_listener._add_issue_id_marks = mock.Mock()
+
+    next(rp_listener.pytest_runtest_protocol(mocked_item))
 
     expect(rp_listener._add_issue_id_marks.call_count == 1,
-            "_add_issue_id_marks called more than 1 time")
+           '_add_issue_id_marks called more than 1 time')
     assert_expectations()
 
 
-@patch('reportportal_client.service.ReportPortalService.get_project_settings')
-def test_is_item_update_supported(request):
-    """Test listener public is_client_support_item_update method."""
+def test_is_item_update_supported(rp_service):
+    """Test listener public is_client_support_item_update method.
+
+    :param rp_service: Pytest fixture
+    """
     func = None
-    rp_service = PyTestServiceClass()
-    rp_service.init_service("endpoint", "project", "uuid", 20, False, [])
 
-    if hasattr(rp_service.rp, "update_test_item"):
-        rp_service.rp.supported_methods.remove("update_test_item")
+    if hasattr(rp_service.rp, 'update_test_item'):
         func = rp_service.rp.update_test_item
-        delattr(type(rp_service.rp), "update_test_item")
-
+        delattr(type(rp_service.rp), 'update_test_item')
 
     result = rp_service.is_item_update_supported()
     expect(result is False,
            "incorrect result for is_client_support_item_update method")
 
     rp_service.rp.update_test_item = func
-    setattr(rp_service.rp, "update_test_item", Mock())
+    setattr(rp_service.rp, 'update_test_item', mock.Mock())
 
     result = rp_service.is_item_update_supported()
     expect(result is True,
-           "incorrect result for is_client_support_item_update method")
+           'incorrect result for is_client_support_item_update method')
     assert_expectations()
 
 
-def test_add_issue_info(request):
-    """Test listener helper _add_issue_info method."""
-    rp_service = Mock()
-    rp_listener = RPReportListener(rp_service)
-    rp_service.issue_types = {"TST": "TEST"}
+def test_add_issue_info(rp_listener, rp_service):
+    """Test listener helper _add_issue_info method.
 
-    report = Mock()
+    :param rp_listener: Pytest fixture
+    :param rp_service:  Pytest fixture
+    """
+    rp_service._issue_types = {"TST": "TEST"}
+
+    report = mock.Mock()
     report.when = "call"
     report.skipped = False
 
@@ -129,24 +121,26 @@ def test_add_issue_info(request):
         for mark in [pytest.mark.issue(issue_id="456823", issue_type="TST")]:
             yield mark
 
-    test_item = Mock()
+    test_item = mock.Mock()
     test_item.session.config.getini = getini
     test_item.iter_markers = iter_markers
 
     rp_listener._add_issue_info(test_item, report)
 
-    expect(rp_listener.issue['issue_type'] == "TEST",
+    expect(rp_listener.issue['issueType'] == "TEST",
            "incorrect test issue_type")
-    expect(rp_listener.issue['comment'] == "* issue: [456823](https://bug.com/456823)",
+    expect(rp_listener.issue['comment'] ==
+           "* issue: [456823](https://bug.com/456823)",
            "incorrect test comment")
     assert_expectations()
 
 
-def test_add_issue_id_marks(request):
-    """Test listener helper _add_issue_id_marks method."""
-    rp_service = Mock()
-    rp_listener = RPReportListener(rp_service)
+def test_add_issue_id_marks(rp_listener, mocked_item):
+    """Test listener helper _add_issue_id_marks method.
 
+    :param rp_listener: Pytest fixture
+    :param mocked_item: Pytest fixture
+    """
     def getini(option):
         if option == "rp_issue_id_marks":
             return True
@@ -158,36 +152,13 @@ def test_add_issue_id_marks(request):
         for mark in [pytest.mark.issue(issue_id="456823")]:
             yield mark
 
-    test_item = Mock()
-    test_item.session.config.getini = getini
-    test_item.iter_markers = iter_markers
+    mocked_item.session.config.getini = getini
+    mocked_item.iter_markers = iter_markers
 
-    rp_listener._add_issue_id_marks(test_item)
+    rp_listener._add_issue_id_marks(mocked_item)
 
-    expect(test_item.add_marker.call_count == 1,
+    expect(mocked_item.add_marker.call_count == 1,
            "item.add_marker called more than 1 time")
-    expect(test_item.add_marker.call_args[0][0] == "issue:456823",
+    expect(mocked_item.add_marker.call_args[0][0] == "issue:456823",
            "item.add_marker called with incorrect parameters")
-    assert_expectations()
-
-
-@patch('pytest_reportportal.plugin.is_master', Mock(return_value=True))
-@pytest.mark.parametrize('shouldfail, outcome', [
-    (False, False), ('stopping after 1 failures', True)
-])
-def test_sessionfinish_with_maxfail(shouldfail, outcome):
-    """Test session_finish logic when the maxfail Pytest argument is in use.
-
-    :param shouldfail: shouldfail attribute value for the Session object
-    :param outcome:    nowait argument value passed to the terminate_service()
-    """
-    mocked_session = Mock()
-    mocked_session.shouldfail = shouldfail
-    mocked_session.config = Mock()
-    mocked_session.config._reportportal_configured = True
-    mocked_session.config.py_test_service.terminate_service = Mock()
-    mocked_session.config.py_test_service.finish_launch = Mock()
-    pytest_sessionfinish(mocked_session)
-    expect(lambda: mocked_session.config.py_test_service.
-        finish_launch.assert_called_with())
     assert_expectations()


### PR DESCRIPTION
What was done:
- dropped support for Python 3.4 due to EOL
- fixed an issue with the 'issue' marker reporting
- reorganized unit tests
- added test stages for Python 3.7 and Python 3.8
- added reporting of the system information to the launch