### PR TITLE
fix  hierarchy issues

### DIFF
--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -225,9 +225,10 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         self._stop_if_necessary()
         if self.rp is None:
             return
-
+        self.parent_item_id = None 
         for part in self._item_parts[test_item]:
             if self._hier_parts[part]["start_flag"]:
+                self.parent_item_id = self._hier_parts[part]["item_id"]
                 continue
             self._hier_parts[part]["start_flag"] = True
 
@@ -374,7 +375,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                     item_dir = dirs_parts[path]
                     rp_name = ""
                 else:
-                    item_dir = File(dir_name, nodeid=dir_name, session=item.session, config=item.session.config)
+                    item_dir = File(dir_path, nodeid=dir_name, session=item.session, config=item.session.config)
                     rp_name += dir_name
                     item_dir._rp_name = rp_name
                     dirs_parts[path] = item_dir


### PR DESCRIPTION
issue1: testsuite parent_item_id is nor correct
if we have 1.py/2.py/3.py in tests folder, then suite hierarchy is: 1.py->2.py->3.py,  but these 3 suites should have same level, not nested.
we should reset parent_item_id to None before loop the root part.

issue2: rp_hierarchy_dirs = True issue
if we enabled this options on macOS, it throw exception at line:378, File class. the first parameter is py.path.local type, not the str type.