### PR TITLE
add env var override for rp_uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 .installed.cfg
 *.egg
 MANIFEST
+.eggs
 
 # Installer logs
 pip-log.txt

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,6 @@ The following parameters are optional:
 If you like to override the above parameters from command line, or from CI environment based on your build, then pass
 - :code:`-o "rp_launch_attributes=Smoke Tests"` during invocation.
 
-If
 
 Examples
 ~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,8 @@ Example of :code:`pytest.ini`:
     rp_ignore_errors = True
     rp_ignore_attributes = 'xfail' 'usefixture'
 
+- The :code:`rp_uuid` can also be set with the environment variable `RP_UUID`. This will override the value set for :code:`rp_uuid` in pytest.ini
+
 The following parameters are optional:
 
 - :code:`rp_launch = AnyLaunchName` - launch name (could be overridden
@@ -100,6 +102,8 @@ The following parameters are optional:
 
 If you like to override the above parameters from command line, or from CI environment based on your build, then pass
 - :code:`-o "rp_launch_attributes=Smoke Tests"` during invocation.
+
+If
 
 Examples
 ~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,6 @@ The following parameters are optional:
 If you like to override the above parameters from command line, or from CI environment based on your build, then pass
 - :code:`-o "rp_launch_attributes=Smoke Tests"` during invocation.
 
-
 Examples
 ~~~~~~~~
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -2,7 +2,7 @@
 # and/or modify it under the terms of the GPL licence
 
 import logging
-import os
+from os import getenv
 import dill as pickle
 import pkg_resources
 import pytest
@@ -53,7 +53,7 @@ def pytest_sessionstart(session):
         session.config.py_test_service.init_service(
             project=session.config.getini('rp_project'),
             endpoint=session.config.getini('rp_endpoint'),
-            uuid=session.config.getini('rp_uuid') if not os.environ.get('RP_UUID') else os.environ['RP_UUID'],
+            uuid=getenv('RP_UUID') or session.config.getini('rp_uuid'),
             log_batch_size=int(session.config.getini('rp_log_batch_size')),
             ignore_errors=bool(session.config.getini('rp_ignore_errors')),
             ignored_attributes=session.config.getini('rp_ignore_attributes'),
@@ -107,7 +107,7 @@ def pytest_configure(config):
 
     project = config.getini('rp_project')
     endpoint = config.getini('rp_endpoint')
-    uuid = config.getini('rp_uuid') if not os.environ.get('RP_UUID') else os.environ['RP_UUID']
+    uuid = getenv('RP_UUID') or config.getini('rp_uuid')
     ignore_errors = config.getini('rp_ignore_errors')
     config._reportportal_configured = all([project, endpoint, uuid])
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -2,6 +2,7 @@
 # and/or modify it under the terms of the GPL licence
 
 import logging
+import os
 import dill as pickle
 import pkg_resources
 import pytest
@@ -52,7 +53,7 @@ def pytest_sessionstart(session):
         session.config.py_test_service.init_service(
             project=session.config.getini('rp_project'),
             endpoint=session.config.getini('rp_endpoint'),
-            uuid=session.config.getini('rp_uuid'),
+            uuid=session.config.getini('rp_uuid') if not os.environ.get('RP_UUID') else os.environ['RP_UUID'],
             log_batch_size=int(session.config.getini('rp_log_batch_size')),
             ignore_errors=bool(session.config.getini('rp_ignore_errors')),
             ignored_attributes=session.config.getini('rp_ignore_attributes'),
@@ -106,7 +107,7 @@ def pytest_configure(config):
 
     project = config.getini('rp_project')
     endpoint = config.getini('rp_endpoint')
-    uuid = config.getini('rp_uuid')
+    uuid = config.getini('rp_uuid') if not os.environ.get('RP_UUID') else os.environ['RP_UUID']
     ignore_errors = config.getini('rp_ignore_errors')
     config._reportportal_configured = all([project, endpoint, uuid])
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read_file(fname):
         return f.read()
 
 
-version = '5.0.3'
+version = '5.0.4'
 
 
 requirements = [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,13 +1,14 @@
 """This modules includes unit tests for the plugin."""
 
 from six.moves import mock
+import os
 
 from delayed_assert import expect, assert_expectations
 import pytest
 from requests.exceptions import RequestException
 
 from pytest_reportportal.listener import RPReportListener
-from pytest_reportportal.plugin import pytest_configure
+from pytest_reportportal.plugin import pytest_configure, pytest_sessionstart
 
 
 @mock.patch('pytest_reportportal.plugin.requests.get')
@@ -138,3 +139,14 @@ def test_add_issue_id_marks(rp_listener, mocked_item):
     expect(mocked_item.add_marker.call_args[0][0] == "issue:456823",
            "item.add_marker called with incorrect parameters")
     assert_expectations()
+
+
+def test_uuid_env_var_override(mocked_session):
+    os.environ['RP_UUID'] = 'foobar'
+    mocked_session.config.py_test_service = mock.Mock()
+    mocked_session.config.option = mock.Mock()
+    mocked_session.config.pluginmanager = mock.Mock()
+    mocked_session.config.py_test_service.init_service = mock.Mock()
+    pytest_sessionstart(mocked_session)
+    args, kwargs = mocked_session.config.py_test_service.init_service.call_args
+    assert kwargs.get('uuid') == 'foobar'

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -142,6 +142,10 @@ def test_add_issue_id_marks(rp_listener, mocked_item):
 
 
 def test_uuid_env_var_override(mocked_session):
+    """
+    Test setting RP_UUID env variable overrides the rp_uuid config value
+    :param mocked_session: pytest fixture
+    """
     os.environ['RP_UUID'] = 'foobar'
     mocked_session.config.py_test_service = mock.Mock()
     mocked_session.config.option = mock.Mock()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -141,12 +141,12 @@ def test_add_issue_id_marks(rp_listener, mocked_item):
     assert_expectations()
 
 
+@mock.patch.dict(os.environ, {'RP_UUID': 'foobar'})
 def test_uuid_env_var_override(mocked_session):
     """
     Test setting RP_UUID env variable overrides the rp_uuid config value
     :param mocked_session: pytest fixture
     """
-    os.environ['RP_UUID'] = 'foobar'
     mocked_session.config.py_test_service = mock.Mock()
     mocked_session.config.option = mock.Mock()
     mocked_session.config.pluginmanager = mock.Mock()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -42,4 +42,3 @@ def test_get_item_parameters(rp_service):
     expect(rp_service._get_parameters(test_item) is None)
 
     assert_expectations()
-


### PR DESCRIPTION
This adds an environment variable override for the pytest.ini attribute `rp_uuid`. When the `RP_UUID` is set it will override the rp_uuid attribute value. The purpose for this is to set an environment variable so the `rp_uuid` does not have to be checked in to the git repository. I am happy to make further changes to set some of the pytest options to be configurable as env variables. 