### PR TITLE
Fixed tests not running when report portal on maintenance

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -104,13 +104,9 @@ def pytest_sessionstart(session):
                 retries=int(session.config.getini('retries')),
             )
         except ResponseError as response_error:
-            msg = str(response_error)
-            if "maintenance" in msg.lower():
-                log.debug("Report portal on maintenance")
-            else:
-                log.debug(msg)
-            log.debug("Reporting is disabled")
-
+            log.warning('Failed to initialize reportportal-client service. '
+                        'Reporting is disabled.')
+            log.debug(str(response_error))
             session.config.py_test_service.rp = None
             return
 

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -81,14 +81,16 @@ def pytest_configure_node(node):
 
 def is_portal_on_maintenance(session):
     """
-    Checks if report portal on maintenance
+    Check if report portal on maintenance.
 
     :param session: Session
     :return: True if response text have word Maintenance, else False
     """
-    base_url_v1 = uri_join(session.config.getini('rp_endpoint'), "api/v1", session.config.getini('rp_project'))
+    base_url_v1 = uri_join(session.config.getini('rp_endpoint'), "api/v1",
+                           session.config.getini('rp_project'))
     url = uri_join(base_url_v1, "settings")
-    headers = {"Authorization": "bearer {0}".format(session.config.getini('rp_uuid'))}
+    headers = {"Authorization": "bearer {0}".format(
+        session.config.getini('rp_uuid'))}
     r = requests.get(url=url, json={}, verify=True, headers=headers)
 
     return True if "Maintenance" in r.text else False
@@ -215,7 +217,7 @@ def pytest_configure(config):
     if not config.option.rp_launch:
         config.option.rp_launch = config.getini('rp_launch')
     if not config.option.rp_launch_description:
-        config.option.rp_launch_description = config.\
+        config.option.rp_launch_description = config. \
             getini('rp_launch_description')
 
     if is_master(config):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -65,7 +65,8 @@ def test_logger_handle_no_attachment(mock_handler, logger, log_level):
 @mock.patch.dict(os.environ, {'RP_UUID': 'foobar'})
 def test_uuid_env_var_override(mocked_session):
     """
-    Test setting RP_UUID env variable overrides the rp_uuid config value
+    Test setting RP_UUID env variable overrides the rp_uuid config value.
+
     :param mocked_session: pytest fixture
     """
     mocked_session.config.py_test_service = mock.Mock()
@@ -86,7 +87,7 @@ def test_get_launch_attributes():
 
 @mock.patch('pytest_reportportal.plugin.requests.get')
 def test_portal_on_maintenance(mocked_get, mocked_session):
-    """Test if portal on maintenance"""
+    """Test if portal on maintenance."""
     mock_response = mock.Mock()
     mock_response.text = "<title>Report Portal - Maintenance</title>"
     mocked_get.return_value = mock_response
@@ -97,7 +98,7 @@ def test_portal_on_maintenance(mocked_get, mocked_session):
 
 @mock.patch('pytest_reportportal.plugin.requests.get')
 def test_portal_not_on_maintenance(mocked_get, mocked_session):
-    """Test if portal not on maintenance"""
+    """Test if portal not on maintenance."""
     mock_response = mock.Mock()
     mock_response.text = "{'project':2,'subTypes':'foobar'}"
     mocked_get.return_value = mock_response

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -63,7 +63,9 @@ def test_logger_handle_no_attachment(mock_handler, logger, log_level):
 
 
 @mock.patch.dict(os.environ, {'RP_UUID': 'foobar'})
-def test_uuid_env_var_override(mocked_session):
+@mock.patch('pytest_reportportal.plugin.is_portal_on_maintenance',
+            return_value=False)
+def test_uuid_env_var_override(mocked_maintenance_check, mocked_session):
     """
     Test setting RP_UUID env variable overrides the rp_uuid config value.
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,7 +10,8 @@ from requests.exceptions import RequestException
 from pytest_reportportal.plugin import (
     get_launch_attributes,
     pytest_configure,
-    pytest_sessionstart
+    pytest_sessionstart,
+    is_portal_on_maintenance
 )
 
 
@@ -81,3 +82,25 @@ def test_get_launch_attributes():
     expected_out = [{'value': 'Tag'}, {'key': 'Key', 'value': 'Value'}]
     out = get_launch_attributes(['Tag', 'Key:Value', ''])
     assert expected_out == out
+
+
+@mock.patch('pytest_reportportal.plugin.requests.get')
+def test_portal_on_maintenance(mocked_get, mocked_session):
+    """Test if portal on maintenance"""
+    mock_response = mock.Mock()
+    mock_response.text = "<title>Report Portal - Maintenance</title>"
+    mocked_get.return_value = mock_response
+    mocked_session.config.getini = mock.Mock()
+
+    assert is_portal_on_maintenance(mocked_session)
+
+
+@mock.patch('pytest_reportportal.plugin.requests.get')
+def test_portal_not_on_maintenance(mocked_get, mocked_session):
+    """Test if portal not on maintenance"""
+    mock_response = mock.Mock()
+    mock_response.text = "{'project':2,'subTypes':'foobar'}"
+    mocked_get.return_value = mock_response
+    mocked_session.config.getini = mock.Mock()
+
+    assert not is_portal_on_maintenance(mocked_session)


### PR DESCRIPTION
Fixed issue https://github.com/reportportal/agent-python-pytest/issues/125
+ Added check if response have word Maintenance in text;
+ Added unit tests.