### PR TITLE
Make it possible to add item attributes as key/value pairs, not just values

### DIFF
--- a/pytest_reportportal/helpers.py
+++ b/pytest_reportportal/helpers.py
@@ -1,0 +1,27 @@
+"""This module includes help functions for both plugin and service modules."""
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def get_attributes(rp_attributes):
+    """Generate list of attributes for RP.
+
+    :param list rp_attributes: rp_attributes option value
+    :return list:                     List of dictionaries to be passed to the
+                                      RP Python client
+    """
+    attrs = []
+    for rp_attr in rp_attributes:
+        try:
+            key, value = rp_attr.split(':')
+            attr_dict = {'key': key, 'value': value}
+        except ValueError:
+            attr_dict = {'value': rp_attr}
+
+        if all(value for value in attr_dict.values()):
+            attrs.append(attr_dict)
+            continue
+        log.debug('Failed to process "{0}" attribute, attribute value'
+                  ' should not be empty.'.format(rp_attr))
+    return attrs

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -42,17 +42,6 @@ def is_master(config):
     return not hasattr(config, 'slaveinput')
 
 
-def get_launch_attributes(rp_launch_attributes):
-    """Generate list of launch attributes for RP.
-
-    :param list rp_launch_attributes: rp_launch_attributes option value
-    :return list:                     List of dictionaries to be passed to the
-                                      RP Python client
-    """
-    launch_attrs = get_attributes(rp_launch_attributes)
-    return launch_attrs
-
-
 @pytest.mark.optionalhook
 def pytest_configure_node(node):
     """
@@ -99,7 +88,7 @@ def pytest_sessionstart(session):
             session.config.py_test_service.rp = None
             return
 
-        attributes = get_launch_attributes(
+        attributes = get_attributes(
             session.config.getini('rp_launch_attributes'))
         session.config.py_test_service.start_launch(
             session.config.option.rp_launch,

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -14,6 +14,7 @@ from pytest_reportportal import LAUNCH_WAIT_TIMEOUT
 from reportportal_client.errors import ResponseError
 from .service import PyTestServiceClass
 from .listener import RPReportListener
+from .helpers import get_attributes
 
 try:
     # This try/except can go away once we support pytest >= 3.3
@@ -48,19 +49,7 @@ def get_launch_attributes(rp_launch_attributes):
     :return list:                     List of dictionaries to be passed to the
                                       RP Python client
     """
-    launch_attrs = []
-    for rp_attr in rp_launch_attributes:
-        try:
-            key, value = rp_attr.split(':')
-            attr_dict = {'key': key, 'value': value}
-        except ValueError:
-            attr_dict = {'value': rp_attr}
-
-        if all(value for value in attr_dict.values()):
-            launch_attrs.append(attr_dict)
-            continue
-        log.debug('Failed to process "{0}" attribute, attribute value'
-                  ' should not be empty.'.format(rp_attr))
+    launch_attrs = get_attributes(rp_launch_attributes)
     return launch_attrs
 
 

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -637,8 +637,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                      for k in item.keywords if get_marker(k) is not None
                      and k not in self.ignored_attributes]
         raw_attrs.extend(item.session.config.getini('rp_tests_attributes'))
-        attributes = get_attributes(raw_attrs)
-        return attributes
+        return get_attributes(raw_attrs)
 
     def _get_parameters(self, item):
         """

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -628,21 +628,16 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
             return "{}:{}".format(keyword, marker.args[0]) \
                 if marker and marker.args else keyword
 
-        # Get launch and test attributes and converting them to key:value form
-        def get_raw_attr(get_marker):
-            raw_attr = [get_marker_value(item, k)
-                        for k in item.keywords if get_marker(k) is not None
-                        and k not in self.ignored_attributes]
-            raw_attr.extend(item.session.config.getini('rp_tests_attributes'))
-            return raw_attr
-
         try:
             get_marker = getattr(item, "get_closest_marker")
         except AttributeError:
             get_marker = getattr(item, "get_marker")
 
-        raw_attributes = get_raw_attr(get_marker)
-        attributes = get_attributes(raw_attributes)
+        raw_attrs = [get_marker_value(item, k)
+                     for k in item.keywords if get_marker(k) is not None
+                     and k not in self.ignored_attributes]
+        raw_attrs.extend(item.session.config.getini('rp_tests_attributes'))
+        attributes = get_attributes(raw_attrs)
         return attributes
 
     def _get_parameters(self, item):

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -637,10 +637,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 and k not in self.ignored_attributes
             ]
 
-            raw_attr.extend([
-                tag
-                for tag in item.session.config.getini('rp_tests_attributes')
-            ])
+            raw_attr.extend(item.session.config.getini('rp_tests_attributes'))
             return raw_attr
 
         try:

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -630,13 +630,9 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
 
         # Get launch and test attributes and converting them to key:value form
         def get_raw_attr(get_marker):
-            raw_attr = [
-                get_marker_value(item, k)
-                for k in item.keywords
-                if get_marker(k) is not None
-                and k not in self.ignored_attributes
-            ]
-
+            raw_attr = [get_marker_value(item, k)
+                        for k in item.keywords if get_marker(k) is not None
+                        and k not in self.ignored_attributes]
             raw_attr.extend(item.session.config.getini('rp_tests_attributes'))
             return raw_attr
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,10 @@
+"""This modules includes unit tests for helpers."""
+
+from pytest_reportportal.helpers import get_attributes
+
+
+def test_get__attributes():
+    """Test get_attributes functionality."""
+    expected_out = [{'value': 'Tag'}, {'key': 'Key', 'value': 'Value'}]
+    out = get_attributes(['Tag', 'Key:Value', ''])
+    assert expected_out == out

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,7 +9,6 @@ from requests.exceptions import RequestException
 
 from reportportal_client.errors import ResponseError
 from pytest_reportportal.plugin import (
-    get_launch_attributes,
     pytest_configure,
     pytest_sessionstart
 )
@@ -76,13 +75,6 @@ def test_uuid_env_var_override(mocked_session):
     pytest_sessionstart(mocked_session)
     args, kwargs = mocked_session.config.py_test_service.init_service.call_args
     assert kwargs.get('uuid') == 'foobar'
-
-
-def test_get_launch_attributes():
-    """Test get_launch_attributes functionality."""
-    expected_out = [{'value': 'Tag'}, {'key': 'Key', 'value': 'Value'}]
-    out = get_launch_attributes(['Tag', 'Key:Value', ''])
-    assert expected_out == out
 
 
 def test_portal_on_maintenance(mocked_session):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12,13 +12,20 @@ def test_item_attributes(mocked_item, rp_service):
 
     def getini(option):
         if option == 'rp_tests_attributes':
-            return ['ini_marker']
+            return ['ini_marker', 'test_ini_key:test_ini_value']
 
     def get_closest_marker(name):
-        return {'test_marker': pytest.mark.test_marker}.get(name)
+        return {'test_marker': pytest.mark.test_marker,
+                'test_decorator_key':
+                    pytest.mark.test_decorator_key('test_decorator_value')
+                }.get(name)
 
     class NodeKeywords(object):
-        _keywords = ['pytestmark', 'ini_marker', 'test_marker']
+        _keywords = ['pytestmark',
+                     'ini_marker',
+                     'test_marker',
+                     'test_decorator_key',
+                     'test_ini_key']
 
         def __iter__(self):
             return iter(self._keywords)
@@ -27,7 +34,12 @@ def test_item_attributes(mocked_item, rp_service):
     mocked_item.keywords = NodeKeywords()
     mocked_item.get_closest_marker = get_closest_marker
     markers = rp_service._get_item_markers(mocked_item)
-    assert markers == [{'value': 'test_marker'}, {'value': 'ini_marker'}]
+    assert markers == [{'value': 'test_marker'},
+                       {'key': 'test_decorator_key',
+                        'value': 'test_decorator_value'},
+                       {'value': 'ini_marker'},
+                       {'key': 'test_ini_key',
+                        'value': 'test_ini_value'}]
 
 
 def test_get_item_parameters(mocked_item, rp_service):
@@ -46,7 +58,6 @@ def test_get_item_parameters(mocked_item, rp_service):
 def test_code_ref_bypass(mocked_item_start, mocked_item, mocked_session,
                          rp_service):
     """ Test that a test code reference constructed and bypassed to a client
-
     :param mocked_item_start: mocked start_test_item method reference
     :param mocked_item:       a mocked test item
     :param mocked_session:    a mocked test session

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -57,7 +57,8 @@ def test_get_item_parameters(mocked_item, rp_service):
 @mock.patch('reportportal_client.service.ReportPortalService.start_test_item')
 def test_code_ref_bypass(mocked_item_start, mocked_item, mocked_session,
                          rp_service):
-    """ Test that a test code reference constructed and bypassed to a client
+    """ Test that a test code reference constructed and bypassed to a client.
+
     :param mocked_item_start: mocked start_test_item method reference
     :param mocked_item:       a mocked test item
     :param mocked_session:    a mocked test session


### PR DESCRIPTION
get_attributes function was moved to a new helpers module. Item attributes can now be added as key/value pairs both in pytest.ini and in decorators