### PR TITLE
Update plugin.py

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -56,7 +56,7 @@ def pytest_configure_node(node):
     node.slaveinput['py_test_service'] = pickle.dumps(node.config.
                                                       py_test_service)
 
-
+@pytest.hookimpl(trylast=True)
 def pytest_sessionstart(session):
     """
     Start test session.


### PR DESCRIPTION
add hookimpl trylast=True to pytest_sessionstarts to insure other sessionstart hooks can manipulate the rp based variables (namely rp_launch_attributes) in ini before the launch is created.