### PR TITLE
fixes #156 - implement rp_launch_id parameter to specify an existing launch to be used by the session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ The following parameters are optional:
 
 - :code:`rp_launch = AnyLaunchName` - launch name (could be overridden
   by pytest --rp-launch option, default value is 'Pytest Launch')
+- :code:`rp_launch_id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` - id of the existing launch (the session will not handle the lifecycle of the given launch)
 - :code:`rp_launch_attributes = 'PyTest' 'Smoke' 'Env:Python3'` - list of attributes for launch
 - :code:`rp_tests_attributes = 'PyTest' 'Smoke'` - list of attributes that will be added for each item in the launch
 - :code:`rp_launch_description = 'Smoke test'` - launch description (could be overridden

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -141,6 +141,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                      ignore_errors,
                      ignored_attributes,
                      verify_ssl=True,
+                     custom_launch=None,
                      retries=0):
         """Update self.rp with the instance of the ReportPortalService."""
         self._errors = queue.Queue()
@@ -159,7 +160,8 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 token=uuid,
                 log_batch_size=log_batch_size,
                 retries=retries,
-                verify_ssl=verify_ssl
+                verify_ssl=verify_ssl,
+                launch_id=custom_launch
             )
             self.project_settings = None
             if self.rp and hasattr(self.rp, "get_project_settings"):


### PR DESCRIPTION
**depends on**: https://github.com/reportportal/client-Python/pull/133

This implements the RFE #156 - we're now able to specify `--rp_launch_id <launch uuid>` cli option(or `launch_id` option in `pytest.ini`) to be used by the RP logger.
When used, the logger doesn't control the launch (start/finish) and we're free to control it by external script (e.g. jenkins pipeline).

Since this depends on https://github.com/reportportal/client-Python/pull/133 to be merged and released, this PR should also include the bumped version of the client-Python package in `requirements.txt`.