### PR TITLE
fixes #225 - add support for pytest-xdist v2

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -36,12 +36,12 @@ log = logging.getLogger(__name__)
 
 def is_master(config):
     """
-    Validate slaveinput attribute.
+    Validate workerinput attribute.
 
     True if the code running the given pytest.config object
     is running in a xdist master node or not running xdist at all.
     """
-    return not hasattr(config, 'slaveinput')
+    return not hasattr(config, 'workerinput')
 
 
 @pytest.mark.optionalhook
@@ -55,8 +55,8 @@ def pytest_configure_node(node):
     if node.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
         return
-    node.slaveinput['py_test_service'] = pickle.dumps(node.config.
-                                                      py_test_service)
+    node.workerinput['py_test_service'] = pickle.dumps(
+            node.config.py_test_service)
 
 
 def pytest_sessionstart(session):
@@ -132,7 +132,7 @@ def wait_launch(rp_client):
 
 def pytest_sessionfinish(session):
     """
-    Finish session if has attr  'slaveinput'.
+    Finish session if has attr  'workerinput'.
 
     :param session: pytest.Session
     :return: None
@@ -193,7 +193,7 @@ def pytest_configure(config):
         config.py_test_service = PyTestServiceClass()
     else:
         config.py_test_service = pickle.loads(config.
-                                              slaveinput['py_test_service'])
+                                              workerinput['py_test_service'])
 
     # set Pytest_Reporter and configure it
     if PYTEST_HAS_LOGGING_PLUGIN:

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -220,7 +220,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         hier_param = False
         display_suite_file_name = True
 
-        if not hasattr(session.config, 'slaveinput'):
+        if not hasattr(session.config, 'workerinput'):
             hier_dirs = session.config.getini('rp_hierarchy_dirs')
             hier_module = session.config.getini('rp_hierarchy_module')
             hier_class = session.config.getini('rp_hierarchy_class')


### PR DESCRIPTION
fixes #225
The fix is really easy and it is also backwards compatible (with xdist<2)
The compatibility broke just because upstream removed deprecated alias:
https://github.com/pytest-dev/pytest-xdist/pull/541/files#diff-8db1df3356c9e2971831603998e197e0015b6cb52edcc77eb45ef00210440768L237

All we have to do is to refer to the `workerinput`.