### PR TITLE
Fix --rp-launch-id parsing

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -55,8 +55,8 @@ def pytest_configure_node(node):
     if node.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
         return
-    node.workerinput['py_test_service'] = pickle.dumps(
-            node.config.py_test_service)
+    node.workerinput['py_test_service'] = pickle.dumps(node.config.
+                                                      py_test_service)
 
 
 def pytest_sessionstart(session):

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -55,8 +55,8 @@ def pytest_configure_node(node):
     if node.config._reportportal_configured is False:
         # Stop now if the plugin is not properly configured
         return
-    node.workerinput['py_test_service'] = pickle.dumps(node.config.
-                                                      py_test_service)
+    node.workerinput['py_test_service'] = pickle.dumps(
+            node.config.py_test_service)
 
 
 def pytest_sessionstart(session):
@@ -77,7 +77,7 @@ def pytest_sessionstart(session):
                 uuid=getenv('RP_UUID') or session.config.getini('rp_uuid'),
                 log_batch_size=int(session.config.getini('rp_log_batch_size')),
                 ignore_errors=bool(session.config.getini('rp_ignore_errors')),
-                custom_launch=session.config.getini('rp_launch_id') or None,
+                custom_launch=session.config.option.rp_launch_id or None,
                 ignored_attributes=session.config.getini(
                     'rp_ignore_attributes'),
                 verify_ssl=session.config.getini('rp_verify_ssl'),
@@ -92,7 +92,7 @@ def pytest_sessionstart(session):
 
         attributes = gen_attributes(
             session.config.getini('rp_launch_attributes'))
-        if not session.config.getini('rp_launch_id'):
+        if not session.config.option.rp_launch_id:
             session.config.py_test_service.start_launch(
                 session.config.option.rp_launch,
                 attributes=attributes,
@@ -142,7 +142,7 @@ def pytest_sessionfinish(session):
         return
 
     if is_master(session.config):
-        if not session.config.getini('rp_launch_id'):
+        if not session.config.option.rp_launch_id:
             session.config.py_test_service.finish_launch()
 
 
@@ -188,6 +188,8 @@ def pytest_configure(config):
     if not config.option.rp_launch_description:
         config.option.rp_launch_description = config.\
             getini('rp_launch_description')
+    if not config.option.rp_launch_id:
+        config.option.rp_launch_id = config.getini('rp_launch_id')
 
     if is_master(config):
         config.py_test_service = PyTestServiceClass()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -83,6 +83,7 @@ def test_portal_on_maintenance(mocked_session):
 
     :param mocked_session: pytest fixture
     """
+    mocked_session.config.option = mock.Mock()
     mocked_session.config.py_test_service = mock.Mock()
     mocked_session.config.py_test_service.init_service.side_effect = \
         ResponseError("<title>Report Portal - Maintenance</title>")


### PR DESCRIPTION
the current implementation completely ignores the cli option: `--rp-launch-id` and directly uses the value from the ini file.
This commit fixes it.