### PR TITLE
implement using of custom parent_item for the pytest session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,7 @@ The following parameters are optional:
   by pytest --rp-launch option, default value is 'Pytest Launch')
 - :code:`rp_launch_id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` - id of the existing launch (the session will not handle the lifecycle of the given launch)
 - :code:`rp_launch_attributes = 'PyTest' 'Smoke' 'Env:Python3'` - list of attributes for launch
+- :code:`rp_parent_item_id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` - id of the existing test item for session to use as parent item for the tests (the session will not handle the lifecycle of the given test item)
 - :code:`rp_tests_attributes = 'PyTest' 'Smoke'` - list of attributes that will be added for each item in the launch
 - :code:`rp_launch_description = 'Smoke test'` - launch description (could be overridden
   by pytest --rp-launch-description option, default value is '')

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -205,6 +205,8 @@ def pytest_configure(config):
 
     if not config.option.rp_parent_item_id:
         config.option.rp_parent_item_id = config.getini('rp_parent_item_id')
+    if not config.option.rp_launch_id:
+        config.option.rp_launch_id = config.getini('rp_launch_id')
 
     if is_master(config):
         config.py_test_service = PyTestServiceClass()
@@ -273,7 +275,6 @@ def pytest_addoption(parser):
         help='Launch description (overrides '
              'rp_launch_description config option)')
     group.addoption(
-<<<<<<< HEAD
         '--rp-rerun',
         action='store_true',
         dest='rp_rerun',
@@ -284,14 +285,13 @@ def pytest_addoption(parser):
         dest='rp_rerun_of',
         help='ID of the launch to be marked as a rerun '
              '(use only with rp_rerun=True)')
-=======
+    group.addoption(
         '--rp-parent-item-id',
         action='store',
         dest='rp_parent_item_id',
         help="Create all test item as child items of the given "
              "(already existing) item.")
 
->>>>>>> implement using of custom parent_item for the pytest session
     group.addoption(
         '--reportportal',
         action='store_true',

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -82,6 +82,7 @@ def pytest_sessionstart(session):
                     'rp_ignore_attributes'),
                 verify_ssl=session.config.getini('rp_verify_ssl'),
                 retries=int(session.config.getini('retries')),
+                parent_item_id=session.config.option.rp_parent_item_id or None,
             )
         except ResponseError as response_error:
             log.warning('Failed to initialize reportportal-client service. '
@@ -202,6 +203,9 @@ def pytest_configure(config):
         if not config.option.rp_rerun:
             config.option.rp_rerun = config.getini('rp_rerun')
 
+    if not config.option.rp_parent_item_id:
+        config.option.rp_parent_item_id = config.getini('rp_parent_item_id')
+
     if is_master(config):
         config.py_test_service = PyTestServiceClass()
     else:
@@ -269,6 +273,7 @@ def pytest_addoption(parser):
         help='Launch description (overrides '
              'rp_launch_description config option)')
     group.addoption(
+<<<<<<< HEAD
         '--rp-rerun',
         action='store_true',
         dest='rp_rerun',
@@ -279,6 +284,14 @@ def pytest_addoption(parser):
         dest='rp_rerun_of',
         help='ID of the launch to be marked as a rerun '
              '(use only with rp_rerun=True)')
+=======
+        '--rp-parent-item-id',
+        action='store',
+        dest='rp_parent_item_id',
+        help="Create all test item as child items of the given "
+             "(already existing) item.")
+
+>>>>>>> implement using of custom parent_item for the pytest session
     group.addoption(
         '--reportportal',
         action='store_true',
@@ -417,6 +430,12 @@ def pytest_addoption(parser):
         type='bool',
         default=True,
         help='Adding tag with issue id to the test')
+
+    parser.addini(
+        'rp_parent_item_id',
+        default=None,
+        help="Create all test item as child items of the given "
+             "(already existing) item.")
 
     parser.addini(
         'retries',

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -142,12 +142,14 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                      ignored_attributes,
                      verify_ssl=True,
                      custom_launch=None,
+                     parent_item_id=None,
                      retries=0):
         """Update self.rp with the instance of the ReportPortalService."""
         self._errors = queue.Queue()
         if self.rp is None:
             self.ignore_errors = ignore_errors
             self.ignored_attributes = ignored_attributes
+            self.parent_item_id = parent_item_id
             if self.rp_supports_parameters:
                 self.ignored_attributes = list(
                     set(ignored_attributes).union({'parametrize'}))
@@ -298,7 +300,6 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         if self.rp is None:
             return
 
-        self.parent_item_id = None
         for part in self._item_parts[test_item]:
             if self._hier_parts[part]["start_flag"]:
                 self.parent_item_id = self._hier_parts[part]["item_id"]


### PR DESCRIPTION
Similar to `rp_launch_id`, this adds an option to specify a custom item ID to be used as a parent for all tests across the pytest session.
This is useful when there's a need to build a custom `Launch->level1->...->leveln` test suite structure`
e.g. if users run automation in multiple processes and want to push results to a single Suite.

This also enables usage of `rp_rerun` together with `pytest-xdist` sessions (flat hierarchy), as there's currently a [bug](https://github.com/reportportal/reportportal/issues/1249) which prevents reruns on root-level items.

![rerun_img](https://i.imgur.com/BZpX2bA.png)