### PR TITLE
Bump the dependency version to support --rp-launch-id

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dill>=0.2.7.1
 pytest>=3.0.7
-reportportal-client>=5.0.7
+reportportal-client>=5.0.8
 six>=1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dill>=0.2.7.1
 pytest>=3.0.7
-reportportal-client>=5.0.6
+reportportal-client>=5.0.7
 six>=1.15.0


### PR DESCRIPTION
`reportportal-client` v. 5.0.7 contains [the code](https://github.com/reportportal/client-Python/commit/5766704ef7590170acb47704fb7c10b64fe8e283) required by the `--rp-launch-id` option.