### PR TITLE
Add support for reading rp_endpoint from environment variable

### DIFF
--- a/pytest_reportportal/config.py
+++ b/pytest_reportportal/config.py
@@ -18,7 +18,8 @@ class AgentConfig(object):
         self._rp_rerun = None
         self.pconfig = pytest_config
 
-        self.rp_endpoint = self.pconfig.getini('rp_endpoint')
+        self.rp_endpoint = (getenv('RP_ENDPOINT') or
+                            self.pconfig.getini('rp_endpoint'))
         self.rp_ignore_errors = self.pconfig.getini('rp_ignore_errors')
         self.rp_ignore_attributes = self.pconfig.getini('rp_ignore_attributes')
         self.rp_is_skipped_an_issue = self.pconfig.getini(


### PR DESCRIPTION
Currently, the only way to set the ReportPortal endpoint is through the
pytest.ini file. The patch adds another way by looking for the
environment variable "RP_ENDPOINT" before looking in the pytest.ini
file, similar to how the RP_UUID environment variable works.