### PR TITLE
eden/report_portal_agent branch PR

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -5,21 +5,21 @@
 
 import dill as pickle
 import logging
-import time
-
 import pytest
 import requests
-
-from pytest_reportportal import LAUNCH_WAIT_TIMEOUT
+import time
 from reportportal_client.errors import ResponseError
 from reportportal_client.helpers import gen_attributes
 
+from pytest_reportportal import LAUNCH_WAIT_TIMEOUT
 from .config import AgentConfig
 from .listener import RPReportListener
 from .service import PyTestServiceClass
-
+from .thread_monkey_patch import set_new_thread_init_method, set_new_thread_run_method
 
 log = logging.getLogger(__name__)
+
+set_new_thread_init_method()
 
 
 def check_connection(aconf):
@@ -101,6 +101,7 @@ def pytest_sessionstart(session):
                 retries=config._reporter_config.rp_retries,
                 parent_item_id=config._reporter_config.rp_parent_item_id,
             )
+            set_new_thread_run_method(config.py_test_service.rp)
         except ResponseError as response_error:
             log.warning('Failed to initialize reportportal-client service. '
                         'Reporting is disabled.')

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -93,12 +93,10 @@ def pytest_sessionstart(session):
                 endpoint=config._reporter_config.rp_endpoint,
                 uuid=config._reporter_config.rp_uuid,
                 log_batch_size=config._reporter_config.rp_log_batch_size,
-                is_skipped_an_issue=config._reporter_config.
-                rp_is_skipped_an_issue,
+                is_skipped_an_issue=config._reporter_config.rp_is_skipped_an_issue,
                 ignore_errors=config._reporter_config.rp_ignore_errors,
                 custom_launch=config._reporter_config.rp_launch_id,
-                ignored_attributes=config._reporter_config.
-                rp_ignore_attributes,
+                ignored_attributes=config._reporter_config.rp_ignore_attributes,
                 verify_ssl=config._reporter_config.rp_verify_ssl,
                 retries=config._reporter_config.rp_retries,
                 parent_item_id=config._reporter_config.rp_parent_item_id,

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -102,6 +102,7 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         self.log_batch_size = 20
         self.log_item_id = None
         self.parent_item_id = None
+        self.project_settings = None
         self.rp = None
         self.rp_supports_parameters = True
         try:
@@ -155,7 +156,6 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
                 verify_ssl=verify_ssl,
                 launch_id=custom_launch,
             )
-            self.project_settings = None
             if self.rp and hasattr(self.rp, "get_project_settings"):
                 self.project_settings = self.rp.get_project_settings()
         else:

--- a/pytest_reportportal/thread_monkey_patch.py
+++ b/pytest_reportportal/thread_monkey_patch.py
@@ -1,0 +1,32 @@
+import threading
+
+
+def set_new_thread_init_method():
+    """
+    Override the existing init method of the threading.Thread class in order for it to have the self.parent attribute
+    """
+    old_init = threading.Thread.__init__
+
+    def new_thread_init(self, *args, **kwargs):
+        old_init(self, *args, **kwargs)
+        self.parent = threading.current_thread()
+
+    threading.Thread.__init__ = new_thread_init
+
+
+def set_new_thread_run_method(rp_client):
+    """
+    This function overrides the run method of each thread in order to call to the _log_batch
+    method of the rp_client so the remaining logs of the thread will be uploaded since now threads can be running under
+    nested steps or open new nested steps
+    :param rp_client: The report portal client instance
+    """
+    original_run_method =  threading.Thread.run
+
+    def new_run_method(self):
+        try:
+            original_run_method(self)
+        finally:
+            rp_client._log_batch(None, force=True)
+
+    threading.Thread.run = new_run_method

--- a/pytest_reportportal/thread_nested_steps_classes.py
+++ b/pytest_reportportal/thread_nested_steps_classes.py
@@ -1,0 +1,109 @@
+class NestedStep:
+    """
+    This class contains information about a specific nested step
+    """
+
+    def __init__(self, name, id):
+        self.name = name
+        self.id = id
+
+
+class ThreadNestedSteps:
+    """
+    A class which contains all the information on the nested steps which were created under a certain thread
+    """
+
+    def __init__(self, test_threads_nested_steps, thread, test_item_id):
+        self.thread = thread
+        self.nested_steps_stack = []
+        self.test_item_id = test_item_id
+        self.test_threads_nested_steps = test_threads_nested_steps
+        self.nested_steps_info = {}
+
+    @property
+    def last_nested_step(self):
+        """
+        A property which returns the last nested step in the hierarchy that was created under the thread or None
+        """
+        return None if not self.nested_steps_stack else self.nested_steps_info[self.nested_steps_stack[-1]]
+
+    def add_nested_step(self, step_id, step_name):
+        """
+        This method update the new created step under this instance
+        :param step_id: The id of the nested step
+        :param step_name: The name of the nested step
+        :return:
+        """
+        self.nested_steps_stack.append(step_id)
+        self.nested_steps_info[step_id] = NestedStep(name=step_name, id=step_id)
+
+    def remove_nested_step(self, step_id=None):
+        """
+        This method removes a step from this instance
+        :param step_id: The id of the nested step or None - if None is provided, then this method will remove the
+                        last nested step
+        """
+        if not step_id:
+            step_id = self.nested_steps_stack.pop()
+        else:
+            self.nested_steps_stack.remove(step_id)
+        self.nested_steps_info.pop(step_id)
+
+
+class TestThreadsNestedSteps:
+    """
+    This class manages all the threads that contain nested steps under a specific test
+    This class was created in order to help the RP client to mix logs which were created under nested steps from
+    different threads
+    """
+
+    def __init__(self):
+        self._threads_nested_steps_dict = {}
+        self.test_item_id = None
+        self.nested_steps_exceptions = []
+
+    def __getitem__(self, item):
+        thread_nested_steps = self._threads_nested_steps_dict.get(item)
+        if not thread_nested_steps:
+            raise KeyError(f'No such thread with identifier {item} was found')
+        return thread_nested_steps
+
+    def get(self, thread_ident):
+        """
+        This method accepts a unique id of a thread and returns its ThreadSteps instance
+        :param thread_ident: An id of a certain thread  - int
+        :return: The ThreadNestedSteps instance which contains the information on the steps of the thread
+        """
+        return self._threads_nested_steps_dict.get(thread_ident)
+
+    def add_thread(self, thread):
+        """
+        This method adds a new thread to the _threads_steps_dict in order to be able to save steps information about it
+        :param thread: threading.Thread instance
+        """
+        self._threads_nested_steps_dict[thread.ident] = ThreadNestedSteps(self, thread, self.test_item_id)
+
+    def set_current_test_item(self, test_item_id):
+        """
+        This method init all the relevant dicts and lists and updates the self.test_item_id with the new test item id
+        :param test_item_id: The test item id - str
+        :return:
+        """
+        self.test_item_id = test_item_id
+        self._threads_nested_steps_dict.clear()
+        self.nested_steps_exceptions.clear()
+
+    def get_new_item_parent_id(self, thread):
+        """
+        This method returns the parent item id which the new item (either nested step or log entry) should be created
+        under
+        :param thread: threading.Thread instance
+        :return: The parent item id - str
+        """
+        while thread:
+            thread_nested_steps = self.get(thread.ident)
+            if thread_nested_steps and thread_nested_steps.last_nested_step:
+                return thread_nested_steps.last_nested_step.id
+            thread = getattr(thread, 'parent', None)
+
+        return self.test_item_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dill>=0.2.7.1
-pytest>=3.8.0
+pytest>=3.7.0
 reportportal-client>=5.0.12
 six>=1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dill>=0.2.7.1
 pytest>=3.8.0
-reportportal-client>=5.0.9
+reportportal-client>=5.0.12
 six>=1.15.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 
-__version__ = '5.0.10'
+__version__ = '5.0.11'
 
 
 def read_file(fname):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import setup
 
 
-__version__ = '5.0.9'
+__version__ = '5.0.10'
 
 
 def read_file(fname):


### PR DESCRIPTION
* Fix init_service call code alignment under the pytest_sessionstart hook
* Add fixes to the attributes learning
  - Add support for writing the suite marks as attributes
  - Add support for assigning the mark kwargs as key-values
  attributes
* Move the project_settings attribute to the init method
* Add support for the service.py module to handle changes on the session.items list
  - Add the method update_tests_collection
  - Add fixes to the finish pytest
* Enhance the known issue handling in the listener.py module
  - Set the item status to FAILED even if it failed with xfail
    since it is still a failure
  - Add new line between the bug-id link to the issue description
  - Align some of the code under the _add_issue_info
  - Set the default issue_type to be Product-Bug since today the default
  is To-Investigate and if the engineer assigned a known issue to the test
  it means that no one need to investigate this test anymore
  - In case of report.skipped - set the issueType to be NOT_ISSUE for all phases
  and not only for 'setup' phase since the skip can be also done from within the
  test itself (during the 'call' phase)
* Create the thread_monkey_patch and implement it under the plugin
* Create the thread_nested_steps_classes.py module
  - Create the following classes:
    - NestedStep
    - ThreadNestedSteps
    - TestThreadsNestedSteps
* Enhance the service.py module 
  - Implement the thread_steps_classes under the service module
  - Create the test_threads_steps attribute under the PyTestServiceClass
  - Implement the new attribute under the start_pytest_item
  - Create the 3 methods:
    - start_nested_step
    - finish_nested_step
    - start_stop_nested_step
  - Create the _get_log_item_id method and implement it under the post_log
    method
  - Fix PytestWarning import
* Set the agent version to 5.0.11 under the setup.py