### PR TITLE
Adds support to have attributes with same keys

### DIFF
--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -660,13 +660,14 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         for k in item.keywords:
             if get_marker(k) is not None and k not in self.ignored_attributes:
                 raw_attrs.extend(get_marker_value(item, k))
-        # When we have custom markers with different values, append the raw_attrs with the markers
-        # which were missed initially.
+        # When we have custom markers with different values, append the
+        # raw_attrs with the markers which were missed initially.
         # Adds supports to have two attributes with same keys.
         for cust_marker in item.own_markers:
             for arg in cust_marker.args:
                 custom_arg = "{0}:{1}".format(cust_marker.name, arg)
-                if not (custom_arg in raw_attrs) and cust_marker.name not in self.ignored_attributes:
+                if not (custom_arg in raw_attrs) and \
+                        cust_marker.name not in self.ignored_attributes:
                     raw_attrs.append(custom_arg)
         raw_attrs.extend(item.session.config.getini('rp_tests_attributes'))
         return gen_attributes(raw_attrs)

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -660,6 +660,14 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         for k in item.keywords:
             if get_marker(k) is not None and k not in self.ignored_attributes:
                 raw_attrs.extend(get_marker_value(item, k))
+        # When we have custom markers with different values, append the raw_attrs with the markers
+        # which were missed initially.
+        # Adds supports to have two attributes with same keys.
+        for i in item.own_markers:
+            for arg in i.args:
+                custom_arg = f"{i.name}:{arg}"
+                if not (custom_arg in raw_attrs) and i.name not in self.ignored_attributes:
+                    raw_attrs.append(custom_arg)
         raw_attrs.extend(item.session.config.getini('rp_tests_attributes'))
         return gen_attributes(raw_attrs)
 

--- a/pytest_reportportal/service.py
+++ b/pytest_reportportal/service.py
@@ -663,10 +663,10 @@ class PyTestServiceClass(with_metaclass(Singleton, object)):
         # When we have custom markers with different values, append the raw_attrs with the markers
         # which were missed initially.
         # Adds supports to have two attributes with same keys.
-        for i in item.own_markers:
-            for arg in i.args:
-                custom_arg = f"{i.name}:{arg}"
-                if not (custom_arg in raw_attrs) and i.name not in self.ignored_attributes:
+        for cust_marker in item.own_markers:
+            for arg in cust_marker.args:
+                custom_arg = "{0}:{1}".format(cust_marker.name, arg)
+                if not (custom_arg in raw_attrs) and cust_marker.name not in self.ignored_attributes:
                     raw_attrs.append(custom_arg)
         raw_attrs.extend(item.session.config.getini('rp_tests_attributes'))
         return gen_attributes(raw_attrs)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31,7 +31,6 @@ def test_item_attributes(mocked_item, rp_service):
                      'test_decorator_key_with_multi_value',
                      'test_ini_key']
 
-
         def __iter__(self):
             return iter(self._keywords)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31,12 +31,17 @@ def test_item_attributes(mocked_item, rp_service):
                      'test_decorator_key_with_multi_value',
                      'test_ini_key']
 
+
         def __iter__(self):
             return iter(self._keywords)
 
     mocked_item.session.config.getini = getini
     mocked_item.keywords = NodeKeywords()
     mocked_item.get_closest_marker = get_closest_marker
+    mocked_item.own_markers = [
+            pytest.mark.test_decorator_key('test_decorator_value'),
+            pytest.mark.test_decorator_key('new_decorator_value'),
+        ]
     markers = rp_service._get_item_markers(mocked_item)
     assert markers == [{'value': 'test_marker'},
                        {'key': 'test_decorator_key',
@@ -45,6 +50,8 @@ def test_item_attributes(mocked_item, rp_service):
                         'value': 'test_value1'},
                        {'key': 'test_decorator_key_with_multi_value',
                         'value': 'test_value2'},
+                       {'key': 'test_decorator_key',
+                        'value': 'new_decorator_value'},
                        {'value': 'ini_marker'},
                        {'key': 'test_ini_key',
                         'value': 'test_ini_value'}]
@@ -102,6 +109,7 @@ def test_code_ref_bypass(mocked_item_start, mocked_item, mocked_session,
     mocked_session.items = [mocked_item]
 
     rp_service.collect_tests(mocked_session)
+    mocked_item.own_markers = []
     rp_service.start_pytest_item(mocked_item)
 
     expect(mocked_item_start.call_count == 1, 'One HTTP POST sent')


### PR DESCRIPTION
Report Portal supports having Attributes with same keys. This is important when filtering data on dashboards and having similar attributes on same level. Also helpful in grouping tests. 

New Contributor Alert, Please let me know, if there is anything I missed or need to do to have pr reviewed 