### PR TITLE
Change pytest.mark.optionalhook to pytest.hookimpl to resolve PytestDeprecationWarning

### DIFF
--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -43,7 +43,7 @@ FAILED_LAUNCH_WAIT = 'Failed to initialize reportportal-client service. ' \
                      + 'Reporting is disabled.'
 
 
-@pytest.mark.optionalhook
+@pytest.hookimpl(optionalhook=True)
 def pytest_configure_node(node):
     """Configure xdist node controller.
 


### PR DESCRIPTION
This patch resolves the deprecation warning below.

```
/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pytest_reportportal/plugin.py:46: PytestDeprecationWarning: The hookimpl pytest_configure_node uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.optionalhook

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```
