### PR TITLE
Agent version update to 5.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+## [5.4.2]
+- Client version updated on [5.5.6](https://github.com/reportportal/client-Python/releases/tag/5.5.6), by @simboom
 
 ## [5.4.1]
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dill>=0.3.6
 pytest>=3.8.0
-reportportal-client~=5.5.4
+reportportal-client~=5.5.6
 aenum>=3.1.0
 requests>=2.28.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 from setuptools import setup
 
 
-__version__ = '5.4.2'
+__version__ = '5.5.6'
 
 
 def read_file(fname):


### PR DESCRIPTION
Updated agent version to 5.5.6 which includes the fix for 
https://github.com/reportportal/client-Python/issues/228

Could be as release update