### PR TITLE
Restore rp_display_suite_test_file and fix bug with rp_dir_level

### DIFF
--- a/pytest_reportportal/config.py
+++ b/pytest_reportportal/config.py
@@ -40,6 +40,7 @@ class AgentConfig:
     rp_hierarchy_code: bool
     rp_dir_level: int
     rp_hierarchy_dirs: bool
+    rp_display_suite_test_file: bool
     rp_dir_path_separator: str
     rp_ignore_attributes: set
     rp_is_skipped_an_issue: bool
@@ -80,6 +81,8 @@ class AgentConfig:
                                                  'rp_hierarchy_dirs_level'))
         self.rp_hierarchy_dirs = self.find_option(pytest_config,
                                                   'rp_hierarchy_dirs')
+        self.rp_display_suite_test_file = self.find_option(pytest_config,
+                                                           'rp_display_suite_test_file')
         self.rp_dir_path_separator = \
             self.find_option(pytest_config, 'rp_hierarchy_dir_path_separator')
         self.rp_ignore_attributes = set(self.find_option(pytest_config, 'rp_ignore_attributes') or [])

--- a/pytest_reportportal/plugin.py
+++ b/pytest_reportportal/plugin.py
@@ -502,6 +502,11 @@ def pytest_addoption(parser) -> None:
         type='bool',
         help='Enables hierarchy for directories')
     parser.addini(
+        'rp_display_suite_test_file',
+        default=True,
+        type='bool',
+        help='Show file name in hierarchy. Depends on rp_hierarchy_dirs_level to get deep enough')
+    parser.addini(
         'rp_hierarchy_dir_path_separator',
         default=os.path.sep,
         help='Path separator to display directories in test hierarchy')

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -353,6 +353,7 @@ def test_pytest_addoption_adds_correct_ini_file_arguments():
         'rp_hierarchy_code',
         'rp_hierarchy_dirs_level',
         'rp_hierarchy_dirs',
+        'rp_display_suite_test_file',
         'rp_hierarchy_dir_path_separator',
         'rp_issue_system_url',
         'rp_bts_issue_url',


### PR DESCRIPTION
Hellow,

This PR handles 2 things:
1. Fixes an issue with `rp_dir_level`: in `_remove_root_dirs`, the loop that handles the ROOT node only handled it first child and called `return`.
2. Add back the support for `rp_display_suite_test_file`. It depends on `rp_dir_level` in a way that if the file name appears deep in the hierarchy, it will be kept and not deleted. The default is `True` to keep the current behavior, but if set to `False`, and the `rp_dir_level` is deep enough, the file name will be removed too, and will be left with suites and tests only in the hierarchy.