### PR TITLE
fix: strip trailing @suffix for method_name in _get_code_ref

### DIFF
--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -26,3 +26,47 @@ def test_get_item_parameters(mocked_item, rp_service):
     expect(rp_service._get_parameters(mocked_item) is None)
 
     assert_expectations()
+
+
+def test_get_method_name_regular(mocked_item, rp_service):
+    """Test that regular test names are returned as-is."""
+    mocked_item.name = "test_simple_function"
+    mocked_item.originalname = None
+
+    result = rp_service._get_method_name(mocked_item)
+
+    expect(result == "test_simple_function")
+    assert_expectations()
+
+
+def test_get_method_name_uses_originalname(mocked_item, rp_service):
+    """Test that originalname is preferred when available."""
+    mocked_item.name = "test_verify_data[Daily]@sync_group"
+    mocked_item.originalname = "test_verify_data"
+
+    result = rp_service._get_method_name(mocked_item)
+
+    expect(result == "test_verify_data")
+    assert_expectations()
+
+
+def test_get_method_name_strips_suffix(mocked_item, rp_service):
+    """Test that trailing @suffix is stripped when originalname is None."""
+    mocked_item.name = "test_export_data@data_export"
+    mocked_item.originalname = None
+
+    result = rp_service._get_method_name(mocked_item)
+
+    expect(result == "test_export_data")
+    assert_expectations()
+
+
+def test_get_method_name_preserves_at_inside_params(mocked_item, rp_service):
+    """Test that @ inside parameter brackets is preserved."""
+    mocked_item.name = "test_email[user@example.com]"
+    mocked_item.originalname = None
+
+    result = rp_service._get_method_name(mocked_item)
+
+    expect(result == "test_email[user@example.com]")
+    assert_expectations()


### PR DESCRIPTION
# Description

When using `pytest-xdist` with `--dist=loadgroup`, tests with `xdist_group` markers
get `@group_name` appended to their `nodeid` (e.g., `test_foo@my_group`).

For **parameterized** tests, `item.originalname` is available and correctly used.
For **non-parameterized** tests, `item.originalname` is `None`, so the code falls
back to `item.name` which includes the `@suffix`. This produces an invalid `code_ref`
like `path/file.py:test_foo@group`, causing the test to not appear in ReportPortal.

Note that appending the `@group_name` to the test name is done on purpose in tests with `xdist_group`, see for further details in [here](https://github.com/pytest-dev/pytest-xdist/issues/1200).

## Comparison with pytest-ibutsu

The [pytest-ibutsu](https://github.com/ibutsu/pytest-ibutsu) plugin handles this
correctly by using `item.location[2]` which returns the original function name
without any xdist suffixes:

# pytest-ibutsu/src/pytest_ibutsu/modeling.py:
```
@staticmethod
def _get_test_idents(item: pytest.Item) -> str:
    try:
        return item.location[2]
    except AttributeError:
        ...
```
This PR aligns pytest-reportportal behavior with pytest-ibutsu.

# Solution

Add `_get_method_name()` method that:
1. Returns `item.originalname` if available
2. Otherwise strips trailing `@suffix` from `item.name`
3. Preserves `@` inside parameter brackets (e.g., `test_email[user@example.com]`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved test method name extraction with enhanced handling of parametrized tests and special characters.

* **Tests**
  * Added unit tests for method name resolution logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->